### PR TITLE
Add beta banner to all pages

### DIFF
--- a/app/views/components/_beta_banner.html.erb
+++ b/app/views/components/_beta_banner.html.erb
@@ -1,0 +1,13 @@
+<%=
+  render(
+    partial: 'govuk_component/beta_label',
+    locals: {
+      message: <<-MESSAGE
+        This is a test version of the layout of this page.
+        <a id=taxonomy-survey href='https://www.smartsurvey.co.uk/s/betasurvey2017' target='_blank' rel='noopener noreferrer'>
+          Take the survey to help us improve it
+        </a>
+      MESSAGE
+    }
+  )
+%>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -10,6 +10,7 @@
 
 	<body class="<%= yield :body_classes %>">
 		<div class="wrapper" id="wrapper">
+      <%= render partial: 'components/beta_banner' %>
       <%= content_for?(:content) ? yield(:content) : yield %>
 		</div>
   </body>


### PR DESCRIPTION
The beta banner serves two purposes:
- Remind the user that they are looking at a beta version of the site
- [Hide the survey banner](https://github.com/alphagov/static/blob/14a6b580872d01fd67b6053d440f8abc5cee1c28/app/assets/javascripts/surveys.js#L427) that occasionally pop

### Trello

https://trello.com/c/tOoJJfR6/64-remove-survey-link-from-prototype