### PR TITLE
Pass query strings through to the fall-through method

### DIFF
--- a/app/controllers/content_items_controller.rb
+++ b/app/controllers/content_items_controller.rb
@@ -52,7 +52,7 @@ private
   end
 
   def raw_content_item_html
-    @raw_html ||= open("https://www.gov.uk/#{params[:base_path]}",
+    @raw_html ||= open("https://www.gov.uk#{request.fullpath}",
       # Ensure we get the new version of the page, which should have all content in a two-thirds column
       'Cookie' => 'ABTest-EducationNavigation=B',
     ).read


### PR DESCRIPTION
Pages such as search require query strings to work. By passing this
through to the fall-through method, we can render the search page
directly in the prototype.

### Trello

https://trello.com/c/kBBIMagV/66-redirect-our-search-to-gov-uk-search-q