### PR TITLE
Upgrade navigation helpers

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -63,7 +63,7 @@ GEM
     ffi (1.9.18)
     foreman (0.84.0)
       thor (~> 0.19.1)
-    gds-api-adapters (41.5.0)
+    gds-api-adapters (42.0.0)
       link_header
       lrucache (~> 0.1.1)
       null_logger
@@ -75,8 +75,8 @@ GEM
     govuk_frontend_toolkit (5.2.0)
       rails (>= 3.1.0)
       sass (>= 3.2.0)
-    govuk_navigation_helpers (5.1.0)
-      gds-api-adapters (~> 41.0)
+    govuk_navigation_helpers (6.0.0)
+      gds-api-adapters (~> 42.0)
     http-cookie (1.0.3)
       domain_name (~> 0.5)
     i18n (0.8.1)
@@ -150,7 +150,7 @@ GEM
     remote-sass (0.0.1)
       sass (~> 3.2)
     request_store (1.3.1)
-    rest-client (2.0.1)
+    rest-client (2.0.2)
       http-cookie (>= 1.0.2, < 2.0)
       mime-types (>= 1.16, < 4.0)
       netrc (~> 0.8)


### PR DESCRIPTION
This will allow us to see the related links.

Example page: https://govuk-nav-prototype-pr-9.herokuapp.com/government/publications/national-curriculum-in-england-mathematics-programmes-of-study

Trello: https://trello.com/c/BhsvoHmv/70-related-links-are-not-showing-up-in-the-new-prototype

### Before

<img width="1022" alt="screen shot 2017-04-26 at 15 46 41" src="https://cloud.githubusercontent.com/assets/416701/25440564/b8d6cd8e-2a97-11e7-9481-c86027c12601.png">

### After

<img width="1045" alt="screen shot 2017-04-26 at 15 46 49" src="https://cloud.githubusercontent.com/assets/416701/25440574/bf336d36-2a97-11e7-8db9-b92acaa318ad.png">
