### PR TITLE
Upgrade to govuk_navigation_helpers 6.0.1

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -75,7 +75,7 @@ GEM
     govuk_frontend_toolkit (5.2.0)
       rails (>= 3.1.0)
       sass (>= 3.2.0)
-    govuk_navigation_helpers (6.0.0)
+    govuk_navigation_helpers (6.0.1)
       gds-api-adapters (~> 42.0)
     http-cookie (1.0.3)
       domain_name (~> 0.5)


### PR DESCRIPTION
This fixes the issue with repeated related links across different
taxons.

Trello: https://trello.com/c/I4rs80n1/80-remove-duplicated-related-links-across-all-parent-taxons