### PR TITLE
Sort taxons alphabetically in views

### DIFF
--- a/app/models/taxon.rb
+++ b/app/models/taxon.rb
@@ -32,9 +32,11 @@ class Taxon
   def child_taxons
     return [] unless children?
 
-    linked_items('child_taxons').map do |child_taxon|
+    children = linked_items('child_taxons').map do |child_taxon|
       self.class.new(child_taxon)
     end
+
+    children.sort_by(&:title)
   end
 
   def grandchildren?


### PR DESCRIPTION
The taxons were not being sorted alphabetically like in GOV.UK. This commit fixes that bug.