### PR TITLE
[Do not merge] Highlight high volume content in navigation lists

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -25,3 +25,10 @@ p {
   margin-top: pem(5, 16);
   margin-bottom: pem(20, 16);
 }
+
+.taxon-page .subsection .subsection-list {
+  &.high-volume {
+    border-left: 5px solid $govuk-blue;
+    padding-left: $gutter-one-third;
+  }
+}

--- a/app/controllers/taxons_controller.rb
+++ b/app/controllers/taxons_controller.rb
@@ -7,6 +7,7 @@ class TaxonsController < ApplicationController
       locals: {
         taxon: taxon,
         navigation_helpers: navigation_helpers,
+        mainstream_formats: mainstream_formats,
       }
   end
 
@@ -44,5 +45,21 @@ class TaxonsController < ApplicationController
 
   def taxon_path
     "/#{params[:base_path]}"
+  end
+
+  def mainstream_formats
+    [
+      "answer",
+      "calculator",
+      "calendar",
+      "completed_transaction",
+      "guide",
+      "local_transaction",
+      "place",
+      "programme",
+      "simple_smart_answer",
+      "smart_answer",
+      "transaction"
+    ]
   end
 end

--- a/app/views/taxons/_child_taxons_list.html.erb
+++ b/app/views/taxons/_child_taxons_list.html.erb
@@ -22,6 +22,7 @@
                   <%= render partial: 'content_list_for_child_taxon', locals: {
                       section_index: index,
                       tagged_content: taxon.tagged_content,
+                      mainstream_formats: mainstream_formats
                   } %>
                 </div>
               </div>

--- a/app/views/taxons/_content_list_for_child_taxon.html.erb
+++ b/app/views/taxons/_content_list_for_child_taxon.html.erb
@@ -1,9 +1,24 @@
+<%# loop once for HVC %>
+<ol class="subsection-list high-volume">
+  <% tagged_content.each_with_index do |content_item, index| %>
+    <% if mainstream_formats.include? content_item.content_store_document_type %>
+      <li class="subsection-list-item">
+        <%= link_to(content_item.title, content_item.base_path) %>
+
+        <p><%= content_item.description %></p>
+      </li>
+    <% end %>
+  <% end %>
+</ol>
+<%# and again for regular content %>
 <ol class="subsection-list">
   <% tagged_content.each_with_index do |content_item, index| %>
+    <% unless mainstream_formats.include? content_item.content_store_document_type %>
     <li class="subsection-list-item">
       <%= link_to(content_item.title, content_item.base_path) %>
 
       <p><%= content_item.description %></p>
     </li>
+    <% end %>
   <% end %>
 </ol>

--- a/app/views/taxons/_content_list_for_current_taxon.html.erb
+++ b/app/views/taxons/_content_list_for_current_taxon.html.erb
@@ -10,27 +10,55 @@
             <p><%= taxon.description %></p>
           <% end %>
 
+          <ol class="high-volume">
+            <% tagged_content.each_with_index do |content_item, index| %>
+              <% if mainstream_formats.include? content_item.content_store_document_type %>
+                <li>
+                  <h2>
+                    <%= link_to(
+                      content_item.title,
+                      content_item.base_path,
+                      data: {
+                        track_category: is_grid ? 'navGridLeafLinkClicked' : 'navLeafLinkClicked',
+                        track_action: index + 1,
+                        track_label: content_item.base_path,
+                        track_options: {
+                            dimension28: tagged_content.size.to_s,
+                            dimension29: content_item.title,
+                        },
+                        module: 'track-click',
+                      }
+                      ) %>
+                  </h2>
+                  <p><%= content_item.description %></p>
+                </li>
+              <% end %>
+            <% end %>
+          </ol>
+
           <ol>
             <% tagged_content.each_with_index do |content_item, index| %>
-              <li>
-                <h2>
-                  <%= link_to(
-                    content_item.title,
-                    content_item.base_path,
-                    data: {
-                      track_category: is_grid ? 'navGridLeafLinkClicked' : 'navLeafLinkClicked',
-                      track_action: index + 1,
-                      track_label: content_item.base_path,
-                      track_options: {
-                          dimension28: tagged_content.size.to_s,
-                          dimension29: content_item.title,
-                      },
-                      module: 'track-click',
-                    }
-                    ) %>
-                </h2>
-                <p><%= content_item.description %></p>
-              </li>
+              <% unless mainstream_formats.include? content_item.content_store_document_type %>
+                <li>
+                  <h2>
+                    <%= link_to(
+                      content_item.title,
+                      content_item.base_path,
+                      data: {
+                        track_category: is_grid ? 'navGridLeafLinkClicked' : 'navLeafLinkClicked',
+                        track_action: index + 1,
+                        track_label: content_item.base_path,
+                        track_options: {
+                            dimension28: tagged_content.size.to_s,
+                            dimension29: content_item.title,
+                        },
+                        module: 'track-click',
+                      }
+                      ) %>
+                  </h2>
+                  <p><%= content_item.description %></p>
+                </li>
+              <% end %>
             <% end %>
           </ol>
         </div>

--- a/app/views/taxons/show.html.erb
+++ b/app/views/taxons/show.html.erb
@@ -16,16 +16,19 @@
     taxon: taxon,
     tagged_content: taxon.tagged_content,
     is_grid: true,
+    mainstream_formats: mainstream_formats
   } %>
 <% else %>
   <% if taxon.children? %>
     <%= render partial: 'child_taxons_list', locals: {
       accordion_content: taxon_overview_and_child_taxons(taxon),
+      mainstream_formats: mainstream_formats
     } %>
   <% else %>
     <%= render partial: 'content_list_for_current_taxon', locals: {
       taxon: taxon,
       tagged_content: taxon.tagged_content,
+      mainstream_formats: mainstream_formats
     } %>
   <% end %>
 <% end %>


### PR DESCRIPTION
Show high volume content in accordions before other content is displayed.

## Examples

### Apprenticeships

#### mobile
<img height="400" alt="apprenticeships-mobile" src="https://cloud.githubusercontent.com/assets/523014/25865008/615cd10a-34e9-11e7-86bf-b129d89b70de.png">

#### desktop
<img height="400" alt="apprenticeships-desktop" src="https://cloud.githubusercontent.com/assets/523014/25865024/6d71e688-34e9-11e7-9107-50fec88b534d.png">

### Student finance

#### mobile
<img height="400" alt="student-finance-mobile" src="https://cloud.githubusercontent.com/assets/523014/25865030/72a61d22-34e9-11e7-8455-00b4ac8a771e.png">

#### desktop
<img height="400" alt="student-finance-desktop" src="https://cloud.githubusercontent.com/assets/523014/25865036/7abe59de-34e9-11e7-8111-c5bfd76f8c32.png">
