### PR TITLE
Highlight high volume content on accordion pages

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -25,3 +25,14 @@ p {
   margin-top: pem(5, 16);
   margin-bottom: pem(20, 16);
 }
+
+.high-volume {
+  color: $white;
+  background-color: $govuk-blue;
+  padding: $gutter;
+  margin-bottom: $gutter;
+
+  a {
+    color: $white;
+  }
+}

--- a/app/controllers/taxons_controller.rb
+++ b/app/controllers/taxons_controller.rb
@@ -7,6 +7,7 @@ class TaxonsController < ApplicationController
       locals: {
         taxon: taxon,
         navigation_helpers: navigation_helpers,
+        mainstream_formats: mainstream_formats,
       }
   end
 
@@ -44,5 +45,21 @@ class TaxonsController < ApplicationController
 
   def taxon_path
     "/#{params[:base_path]}"
+  end
+
+  def mainstream_formats
+    [
+      "answer",
+      "calculator",
+      "calendar",
+      "completed_transaction",
+      "guide",
+      "local_transaction",
+      "place",
+      "programme",
+      "simple_smart_answer",
+      "smart_answer",
+      "transaction"
+    ]
   end
 end

--- a/app/controllers/taxons_controller.rb
+++ b/app/controllers/taxons_controller.rb
@@ -1,5 +1,6 @@
 class TaxonsController < ApplicationController
   helper_method :taxon_overview_and_child_taxons
+  helper_method :mainstream_content
 
   def show
     render :show,
@@ -61,5 +62,21 @@ class TaxonsController < ApplicationController
       "smart_answer",
       "transaction"
     ]
+  end
+
+  def mainstream_content(taxon)
+    return_array = []
+
+    return_array << taxon.tagged_content.select do |content_item|
+      mainstream_formats.include? content_item.content_store_document_type
+    end
+
+    taxon.child_taxons.each do |child|
+      return_array << child.tagged_content.select do |content_item|
+        mainstream_formats.include? content_item.content_store_document_type
+      end
+    end
+
+    return_array.flatten.uniq{|item| item.base_path}.sort_by(&:title)
   end
 end

--- a/app/controllers/taxons_controller.rb
+++ b/app/controllers/taxons_controller.rb
@@ -67,13 +67,25 @@ class TaxonsController < ApplicationController
   def mainstream_content(taxon)
     return_array = []
 
-    return_array << taxon.tagged_content.select do |content_item|
-      mainstream_formats.include? content_item.content_store_document_type
-    end
+    if Config.high_volume_content.include?(taxon.base_path)
+      return_array << taxon.tagged_content.select do |content_item|
+        Config.high_volume_content[taxon.base_path].include? content_item.base_path
+      end
 
-    taxon.child_taxons.each do |child|
-      return_array << child.tagged_content.select do |content_item|
+      taxon.child_taxons.each do |child|
+        return_array << child.tagged_content.select do |content_item|
+          Config.high_volume_content[taxon.base_path].include? content_item.base_path
+        end
+      end
+    else
+      return_array << taxon.tagged_content.select do |content_item|
         mainstream_formats.include? content_item.content_store_document_type
+      end
+
+      taxon.child_taxons.each do |child|
+        return_array << child.tagged_content.select do |content_item|
+          mainstream_formats.include? content_item.content_store_document_type
+        end
       end
     end
 

--- a/app/services/config.rb
+++ b/app/services/config.rb
@@ -17,6 +17,12 @@ class Config
     )
   end
 
+  def self.high_volume_content
+    @high_volume_content ||= JSON.parse(
+      load_config('high_volume_content.json')
+    )
+  end
+
   def self.load_config(filename)
     File.read(
       Rails.root.join(

--- a/app/views/taxons/_child_taxons_list.html.erb
+++ b/app/views/taxons/_child_taxons_list.html.erb
@@ -22,6 +22,7 @@
                   <%= render partial: 'content_list_for_child_taxon', locals: {
                       section_index: index,
                       tagged_content: taxon.tagged_content,
+                      mainstream_formats: mainstream_formats
                   } %>
                 </div>
               </div>

--- a/app/views/taxons/_child_taxons_list.html.erb
+++ b/app/views/taxons/_child_taxons_list.html.erb
@@ -2,7 +2,7 @@
 <div class="grid-row">
   <div class="column-two-thirds">
     <div class="high-volume">
-      <h2>Popular guidance in this topic</h2>
+      <h2>Most viewed in this topic</h2>
       <ol>
         <% mainstream_content.each do |content_item| %>
           <li><%= link_to(content_item.title, content_item.base_path) %></li>

--- a/app/views/taxons/_child_taxons_list.html.erb
+++ b/app/views/taxons/_child_taxons_list.html.erb
@@ -1,14 +1,7 @@
 <% if mainstream_content.present? %>
 <div class="grid-row">
   <div class="column-two-thirds">
-    <div class="high-volume">
-      <h2>Most viewed in this topic</h2>
-      <ol>
-        <% mainstream_content.each do |content_item| %>
-          <li><%= link_to(content_item.title, content_item.base_path) %></li>
-        <% end %>
-      </ol>
-    </div>
+    <%= render partial: 'high-volume', locals: { mainstream_content: mainstream_content } %>
   </div>
 </div>
 <% end %>

--- a/app/views/taxons/_child_taxons_list.html.erb
+++ b/app/views/taxons/_child_taxons_list.html.erb
@@ -1,3 +1,18 @@
+<% if mainstream_content.present? %>
+<div class="grid-row">
+  <div class="column-two-thirds">
+    <div class="high-volume">
+      <h2>Popular guidance</h2>
+      <ol>
+        <% mainstream_content.each do |content_item| %>
+          <li><%= link_to(content_item.title, content_item.base_path) %></li>
+        <% end %>
+      </ol>
+    </div>
+  </div>
+</div>
+<% end %>
+
 <% if accordion_content.present? %>
   <div class="grid-row child-topic-contents">
     <div class="column-two-thirds">

--- a/app/views/taxons/_child_taxons_list.html.erb
+++ b/app/views/taxons/_child_taxons_list.html.erb
@@ -2,7 +2,7 @@
 <div class="grid-row">
   <div class="column-two-thirds">
     <div class="high-volume">
-      <h2>Popular guidance</h2>
+      <h2>Popular guidance in this topic</h2>
       <ol>
         <% mainstream_content.each do |content_item| %>
           <li><%= link_to(content_item.title, content_item.base_path) %></li>

--- a/app/views/taxons/_content_list_for_current_taxon.html.erb
+++ b/app/views/taxons/_content_list_for_current_taxon.html.erb
@@ -10,6 +10,10 @@
             <p><%= taxon.description %></p>
           <% end %>
 
+          <% if mainstream_content.present? %>
+            <%= render partial: 'high-volume', locals: { mainstream_content: mainstream_content } %>
+          <% end %>
+
           <ol>
             <% tagged_content.each_with_index do |content_item, index| %>
               <li>

--- a/app/views/taxons/_high-volume.html.erb
+++ b/app/views/taxons/_high-volume.html.erb
@@ -1,0 +1,8 @@
+<div class="high-volume">
+  <h2>Most viewed in this topic</h2>
+  <ol>
+    <% mainstream_content.each do |content_item| %>
+      <li><%= link_to(content_item.title, content_item.base_path) %></li>
+    <% end %>
+  </ol>
+</div>

--- a/app/views/taxons/show.html.erb
+++ b/app/views/taxons/show.html.erb
@@ -16,16 +16,19 @@
     taxon: taxon,
     tagged_content: taxon.tagged_content,
     is_grid: true,
+    mainstream_formats: mainstream_formats
   } %>
 <% else %>
   <% if taxon.children? %>
     <%= render partial: 'child_taxons_list', locals: {
       accordion_content: taxon_overview_and_child_taxons(taxon),
+      mainstream_formats: mainstream_formats
     } %>
   <% else %>
     <%= render partial: 'content_list_for_current_taxon', locals: {
       taxon: taxon,
       tagged_content: taxon.tagged_content,
+      mainstream_formats: mainstream_formats
     } %>
   <% end %>
 <% end %>

--- a/app/views/taxons/show.html.erb
+++ b/app/views/taxons/show.html.erb
@@ -16,7 +16,8 @@
     taxon: taxon,
     tagged_content: taxon.tagged_content,
     is_grid: true,
-    mainstream_formats: mainstream_formats
+    mainstream_formats: mainstream_formats,
+    mainstream_content: nil
   } %>
 <% else %>
   <% if taxon.children? %>

--- a/app/views/taxons/show.html.erb
+++ b/app/views/taxons/show.html.erb
@@ -29,7 +29,8 @@
     <%= render partial: 'content_list_for_current_taxon', locals: {
       taxon: taxon,
       tagged_content: taxon.tagged_content,
-      mainstream_formats: mainstream_formats
+      mainstream_formats: mainstream_formats,
+      mainstream_content: mainstream_content(taxon)
     } %>
   <% end %>
 <% end %>

--- a/app/views/taxons/show.html.erb
+++ b/app/views/taxons/show.html.erb
@@ -22,7 +22,8 @@
   <% if taxon.children? %>
     <%= render partial: 'child_taxons_list', locals: {
       accordion_content: taxon_overview_and_child_taxons(taxon),
-      mainstream_formats: mainstream_formats
+      mainstream_formats: mainstream_formats,
+      mainstream_content: mainstream_content(taxon)
     } %>
   <% else %>
     <%= render partial: 'content_list_for_current_taxon', locals: {

--- a/config/high_volume_content.json
+++ b/config/high_volume_content.json
@@ -1,0 +1,72 @@
+{
+  "/education/funding-and-finance-for-students": [
+    "/student-finance-register-login",
+    "/student-finance-calculator",
+    "/student-finance-forms",
+    "/student-finance",
+    "/contact-student-finance-england",
+    "/apply-online-for-student-finance",
+    "/apply-for-student-finance",
+    "/funding-for-postgraduate-study",
+    "/postgraduate-loan",
+    "/childcare-grant"
+  ],
+  "/education/apprenticeships-traineeships-and-internships": [
+    "/apply-apprenticeship",
+    "/apprenticeships-guide",
+    "/find-traineeship",
+    "/take-on-an-apprentice",
+    "/employment-rights-for-interns",
+    "/find-internship",
+    "/complainfurthereducationapprenticeship",
+    "/employ-trainees"
+  ],
+  "/education/starting-and-attending-school": [
+    "/school-term-holiday-dates",
+    "/apply-for-primary-school-place",
+    "/school-performance-tables",
+    "/apply-free-school-meals",
+    "/apply-for-secondary-school-place",
+    "/home-education",
+    "/schools-admissions",
+    "/home-schooling-information-council",
+    "/help-school-clothing-costs",
+    "/check-school-closure"
+  ],
+  "/education/student-grants-bursaries-scholarships": [
+    "/student-finance-register-login",
+    "/student-finance-calculator",
+    "/student-finance-forms",
+    "/student-finance",
+    "/contact-student-finance-england",
+    "/apply-online-for-student-finance",
+    "/apply-for-student-finance",
+    "/funding-for-postgraduate-study",
+    "/grant-bursary-adult-learners",
+    "/disabled-students-allowances-dsas"
+  ],
+  "/education/sending-a-child-to-school": [
+    "/school-term-holiday-dates",
+    "/apply-for-primary-school-place",
+    "/school-performance-tables",
+    "/apply-for-secondary-school-place",
+    "/schools-admissions",
+    "/check-school-closure",
+    "/school-uniform",
+    "/types-of-school",
+    "/school-meals-healthy-eating-standards",
+    "/school-attendance-absence"
+  ],
+  "/education/student-loans-bursaries-and-sponsorship": [
+    "/student-finance-register-login",
+    "/student-finance-calculator",
+    "/student-finance-forms",
+    "/student-finance",
+    "/contact-student-finance-england",
+    "/apply-online-for-student-finance",
+    "/apply-for-student-finance",
+    "/funding-for-postgraduate-study",
+    "/postgraduate-loan",
+    "/advanced-learner-loan"
+  ]
+}


### PR DESCRIPTION
Duplicate of #16 with cleaned up git history

Show high volume content in a call out at the top of an accordion page

## Examples

### Apprenticeships

#### mobile
<img height="400" alt="apprenticeships-mobile" src="https://cloud.githubusercontent.com/assets/523014/25865128/c66836de-34e9-11e7-9b9f-f2654e3f081b.png">

#### desktop
<img height="400" alt="apprenticeships-desktop" src="https://cloud.githubusercontent.com/assets/523014/25865130/c8c9cc4e-34e9-11e7-884c-1e41c874a24a.png">

### Student finance

#### mobile
<img height="400" alt="student-finance-mobile" src="https://cloud.githubusercontent.com/assets/523014/25865143/d1d865c0-34e9-11e7-8701-16a5e3f4c1e3.png">

#### desktop
<img height="400" alt="student-finance-desktop" src="https://cloud.githubusercontent.com/assets/523014/25865151/d74d6ad2-34e9-11e7-9b4f-558def1d7738.png">
