### PR TITLE
Rescue ContentItemAppender from Gone responses

### DIFF
--- a/app/middleware/content_item_appender.rb
+++ b/app/middleware/content_item_appender.rb
@@ -10,8 +10,8 @@ class ContentItemAppender
     base_path = env['PATH_INFO']
     begin
       env['content_item'] = Services.content_store.content_item(base_path) if path_has_no_format?(base_path)
-    rescue GdsApi::ContentStore::ItemNotFound
-      # Ignore NotFound, and just don't set env['content_item']
+    rescue GdsApi::ContentStore::ItemNotFound, GdsApi::HTTPGone
+      # Ignore NotFound and Gone, and just don't set env['content_item']
     end
     @app.call(env)
   end


### PR DESCRIPTION
The endpoint `/api/content/` now responds with a `410` response.
The ContentItemAppender should just swallow this error like it already
does with `404`.