### PR TITLE
Add missing Sass dependency

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -8,6 +8,7 @@
 
 // These stylesheets are being fetched from GitHub via RemoteSass
 // From the collections app
+@import "views/_browse.scss";
 @import 'views/_taxons.scss';
 @import 'views/_email-signups.scss';
 


### PR DESCRIPTION
Heroku currently doesn't deploy because we're missing a Sass dependency. This change adds that dependency.