### PR TITLE
Log paths visited in the application with a timestamp

### DIFF
--- a/app.json
+++ b/app.json
@@ -37,6 +37,9 @@
   "buildpacks": [
     {
       "url": "https://github.com/heroku/heroku-buildpack-ruby"
+    },
+    {
+      "url": "https://github.com/heroku/exec-buildpack"
     }
   ],
   "addons": []

--- a/app/middleware/path_logger.rb
+++ b/app/middleware/path_logger.rb
@@ -1,0 +1,24 @@
+require 'csv'
+
+# This middleware logs routes visited to help in user lab analysis
+class PathLogger
+  def initialize(app)
+    @app = app
+  end
+
+  def call(env)
+    path = env['PATH_INFO']
+    if should_log?(path)
+      File.open(Rails.root.join('log', 'paths.log'), 'a+') do |file|
+        file.puts [Time.zone.now.iso8601, path].to_csv
+      end
+    end
+    @app.call(env)
+  end
+
+  # Check that the path does not have a dot (.) in it, which indicates that we shouldn't try to fetch a content store
+  # item for it
+  def should_log?(path)
+    /\./ !~ path
+  end
+end

--- a/config/application.rb
+++ b/config/application.rb
@@ -22,5 +22,6 @@ module GovukNavPrototype
     ]
 
     config.middleware.use 'ContentItemAppender'
+    config.middleware.use 'PathLogger'
   end
 end


### PR DESCRIPTION
In order to help determine user journeys during lab sessions, and whether they were "successful" or not, this change adds some very rudimentary path logging to the prototype, logging just the path visited and the timestamp.

The log is updated every time a path is routed through the application. This notably excludes accordion hash changes, so won't track which sections were opened.

Logs are stored locally on the running instance in `logs/paths.log`

### Trello

https://trello.com/c/eBBBri7v/220-track-pageviews-in-the-prototype