### PR TITLE
Hardcode Parenting and Childcare taxonomy

### DIFF
--- a/app/services/config.rb
+++ b/app/services/config.rb
@@ -17,6 +17,12 @@ class Config
     )
   end
 
+  def self.taxons
+    @taxons ||= JSON.parse(
+      load_config('taxons.json')
+    )
+  end
+
   def self.load_config(filename)
     File.read(
       Rails.root.join(

--- a/app/services/content_store.rb
+++ b/app/services/content_store.rb
@@ -8,11 +8,39 @@ module Services
 
   class ContentStore
     def content_item(base_path)
-      content_store_response = content_store.content_item(base_path)
+      content_store_response = local_taxons_by_base_path[base_path] || content_store.content_item(base_path)
+      add_local_taxons!(content_store_response)
       ContentItemMutator.mutate_content_item(content_store_response)
     end
 
     private
+
+    def local_taxons_by_base_path
+      @local_taxons_by_base_path ||= Config.taxons.each_with_object({}) do |taxon, hash|
+        hash[taxon['base_path']] = taxon
+      end
+    end
+
+    def local_taxons_by_content_id
+      @local_taxons_by_content_id ||= Config.taxons.each_with_object({}) do |taxon, hash|
+        hash[taxon['content_id']] = taxon
+      end
+    end
+
+    def add_local_taxons!(content_item)
+      search_result = Services.rummager.search(
+        start: 0,
+        count: RummagerSearch::PAGE_SIZE_TO_GET_EVERYTHING,
+        filter_link: content_item['base_path'],
+        fields: %w[taxons],
+      ).to_h['results'][0] || {}
+
+      taxon_ids = search_result['taxons'] || []
+      content_item['links']['taxons'] ||= [] if taxon_ids.any?
+      taxon_ids
+        .map { |taxon_id| local_taxons_by_content_id[taxon_id] }
+        .each { |taxon| content_item['links']['taxons'] << taxon if taxon }
+    end
 
     def content_store
       @content_store ||=

--- a/config/taxons.json
+++ b/config/taxons.json
@@ -1,0 +1,4883 @@
+[
+  {
+    "base_path": "/childcare-parenting",
+    "content_id": "206b7f3a-49b5-476f-af0f-fd27e2a68473",
+    "title": "Parenting, childcare and children's services ",
+    "description": "Health and welfare, financial help, finding a school, adoption, looked-after children, safeguarding.",
+    "document_type": "taxon",
+    "publishing_app": "content-tagger",
+    "rendering_app": "collections",
+    "schema_name": "taxon",
+    "user_journey_document_supertype": "finding",
+    "links": {
+      "child_taxons": [
+        {
+          "base_path": "/childcare-parenting/safeguarding-and-social-care-for-children",
+          "content_id": "20eb4e84-98ee-404b-a4bd-fe8a36d5d71d",
+          "title": "Safeguarding and social care for children",
+          "description": "Child protection, children in care, become a social care provide. ",
+          "document_type": "taxon",
+          "publishing_app": "content-tagger",
+          "rendering_app": "collections",
+          "schema_name": "taxon",
+          "user_journey_document_supertype": "finding",
+          "links": {
+            "child_taxons": [
+              {
+                "base_path": "/childcare-parenting/child-and-family-social-work",
+                "content_id": "df68fd4e-8e6f-4473-a24a-6033d65fb1d0",
+                "title": "Child and family social work",
+                "description": "Knowledge and skills statements. Inter-agency safeguarding. Guidance on becoming a social worker.",
+                "document_type": "taxon",
+                "publishing_app": "content-tagger",
+                "rendering_app": "collections",
+                "schema_name": "taxon",
+                "user_journey_document_supertype": "finding",
+                "links": {
+                  "child_taxons": []
+                }
+              },
+              {
+                "base_path": "/education/safeguarding-child-protection",
+                "content_id": "5af6180c-d5db-4cc1-a68e-7bd066908132",
+                "title": "Safeguarding and child protection",
+                "description": "Prevent neglect and abuse, homeless children, data collection. ",
+                "document_type": "taxon",
+                "publishing_app": "content-tagger",
+                "rendering_app": "collections",
+                "schema_name": "taxon",
+                "user_journey_document_supertype": "finding",
+                "links": {
+                  "child_taxons": [
+                    {
+                      "base_path": "/childcare-parenting/child-abduction-cross-border-child-protection",
+                      "content_id": "d58bd4de-3fee-4953-9654-7551333eebf1",
+                      "title": "Child abduction and cross-border child protection",
+                      "description": "International child protection cases. Guidance on working with foreign agencies.",
+                      "document_type": "taxon",
+                      "publishing_app": "content-tagger",
+                      "rendering_app": "collections",
+                      "schema_name": "taxon",
+                      "user_journey_document_supertype": "finding",
+                      "links": {
+                        "child_taxons": []
+                      }
+                    },
+                    {
+                      "base_path": "/childcare-parenting/data-collection-safeguarding-child-protection",
+                      "content_id": "d36f331f-ef4e-48e2-81e5-c4ed6c94a1f9",
+                      "title": "Data collection for safeguarding and child protection",
+                      "description": "Children in need census collect reports. Child death data collection.",
+                      "document_type": "taxon",
+                      "publishing_app": "content-tagger",
+                      "rendering_app": "collections",
+                      "schema_name": "taxon",
+                      "user_journey_document_supertype": "finding",
+                      "links": {
+                        "child_taxons": []
+                      }
+                    },
+                    {
+                      "base_path": "/childcare-parenting/preventing-neglect-abuse-and-exploitation",
+                      "content_id": "47fbdb87-b4ff-432a-a4cf-a2f2468ff6d4",
+                      "title": "Preventing neglect, abuse and exploitation",
+                      "description": "Online safety. Reporting and dealing with allegations of abuse. Female genital mutiliation (FGM).",
+                      "document_type": "taxon",
+                      "publishing_app": "content-tagger",
+                      "rendering_app": "collections",
+                      "schema_name": "taxon",
+                      "user_journey_document_supertype": "finding",
+                      "links": {
+                        "child_taxons": []
+                      }
+                    },
+                    {
+                      "base_path": "/childcare-parenting/refugee-runaway-and-homeless-children",
+                      "content_id": "fbe2ce17-9ee6-4dcb-a523-ae5383d2cf4c",
+                      "title": "Refugee, runaway and homeless children",
+                      "description": "Guidance to stop children going missing, and to protect those who do.",
+                      "document_type": "taxon",
+                      "publishing_app": "content-tagger",
+                      "rendering_app": "collections",
+                      "schema_name": "taxon",
+                      "user_journey_document_supertype": "finding",
+                      "links": {
+                        "child_taxons": []
+                      }
+                    },
+                    {
+                      "base_path": "/childcare-parenting/serious-case-reviews",
+                      "content_id": "e626b2fd-203e-4e2e-b8a5-121896ae22e7",
+                      "title": "Serious case reviews",
+                      "description": "Improving safeguarding after the serious injury or death of a child.",
+                      "document_type": "taxon",
+                      "publishing_app": "content-tagger",
+                      "rendering_app": "collections",
+                      "schema_name": "taxon",
+                      "user_journey_document_supertype": "finding",
+                      "links": {
+                        "child_taxons": []
+                      }
+                    }
+                  ]
+                }
+              },
+              {
+                "base_path": "/childcare-parenting/looked-after-children-children-in-care",
+                "content_id": "431a7fac-a2e8-4ffc-8fc7-bab10fc5e6d4",
+                "title": "Looked-after children and children in care",
+                "description": "Children's homes, data collection, children leaving care. ",
+                "document_type": "taxon",
+                "publishing_app": "content-tagger",
+                "rendering_app": "collections",
+                "schema_name": "taxon",
+                "user_journey_document_supertype": "finding",
+                "links": {
+                  "child_taxons": [
+                    {
+                      "base_path": "/childcare-parenting/childrens-homes-and-other-accommodation",
+                      "content_id": "50904cbc-3cde-4a3b-92ba-b75117671574",
+                      "title": "Children's homes and other accommodation",
+                      "description": "Securing a place. Regulations and quality standards, children's privacy and confidentiality.",
+                      "document_type": "taxon",
+                      "publishing_app": "content-tagger",
+                      "rendering_app": "collections",
+                      "schema_name": "taxon",
+                      "user_journey_document_supertype": "finding",
+                      "links": {
+                        "child_taxons": []
+                      }
+                    },
+                    {
+                      "base_path": "/childcare-parenting/children-and-young-people-leaving-care",
+                      "content_id": "d5c3d032-2c12-4bb3-8340-3cc5084ccba7",
+                      "title": "Children and young people leaving care",
+                      "description": "Care leavers' charter, council responsibilities. Staying put arrangements.",
+                      "document_type": "taxon",
+                      "publishing_app": "content-tagger",
+                      "rendering_app": "collections",
+                      "schema_name": "taxon",
+                      "user_journey_document_supertype": "finding",
+                      "links": {
+                        "child_taxons": []
+                      }
+                    },
+                    {
+                      "base_path": "/childcare-parenting/data-collection-for-looked-after-children",
+                      "content_id": "c359fa76-88ff-4298-817e-5cf974473853",
+                      "title": "Data collection for looked-after children",
+                      "description": "Submitting data. Validation rules, technical specification.",
+                      "document_type": "taxon",
+                      "publishing_app": "content-tagger",
+                      "rendering_app": "collections",
+                      "schema_name": "taxon",
+                      "user_journey_document_supertype": "finding",
+                      "links": {
+                        "child_taxons": []
+                      }
+                    }
+                  ]
+                }
+              },
+              {
+                "base_path": "/childcare-parenting/childrens-social-care-providers",
+                "content_id": "454b3d57-870e-4691-a700-abbf7d883c34",
+                "title": "Children's social care providers",
+                "description": "Registering, inspections, complaints, roles and responsibilities. Children's Act 1989 court orders.",
+                "document_type": "taxon",
+                "publishing_app": "content-tagger",
+                "rendering_app": "collections",
+                "schema_name": "taxon",
+                "user_journey_document_supertype": "finding",
+                "links": {
+                  "child_taxons": [
+                    {
+                      "base_path": "/childcare-parenting/inspection-of-childrens-social-care-providers",
+                      "content_id": "689bb0dd-bd50-42e0-9195-cfb020bc3ee7",
+                      "title": "Inspection of children's social care providers",
+                      "description": "Improvement notices, completing an evidence base, children's homes.",
+                      "document_type": "taxon",
+                      "publishing_app": "content-tagger",
+                      "rendering_app": "collections",
+                      "schema_name": "taxon",
+                      "user_journey_document_supertype": "finding",
+                      "links": {
+                        "child_taxons": []
+                      }
+                    },
+                    {
+                      "base_path": "/childcare-parenting/becoming-a-childrens-social-care-provider",
+                      "content_id": "45a65707-11c7-4e58-88b7-164f83d073e6",
+                      "title": "Becoming a children's social care provider",
+                      "description": "Application checklist, assessment questionnaire. How to register.",
+                      "document_type": "taxon",
+                      "publishing_app": "content-tagger",
+                      "rendering_app": "collections",
+                      "schema_name": "taxon",
+                      "user_journey_document_supertype": "finding",
+                      "links": {
+                        "child_taxons": []
+                      }
+                    },
+                    {
+                      "base_path": "/childcare-parenting/social-care-provider-complaints",
+                      "content_id": "49043bab-0075-414b-969b-b144539eef05",
+                      "title": "Social care provider complaints",
+                      "description": "Raise a complaint or concern about a social care provider.",
+                      "document_type": "taxon",
+                      "publishing_app": "content-tagger",
+                      "rendering_app": "collections",
+                      "schema_name": "taxon",
+                      "user_journey_document_supertype": "finding",
+                      "links": {
+                        "child_taxons": []
+                      }
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        },
+        {
+          "base_path": "/childcare-parenting/adoption-fostering-and-surrogacy",
+          "content_id": "5a9e6b26-ae64-4129-93ee-968028381e83",
+          "title": "Adoption, fostering and surrogacy",
+          "description": "Becoming a foster carer, adopting a child from the UK or abroad, looking after someone else's child.",
+          "document_type": "taxon",
+          "publishing_app": "content-tagger",
+          "rendering_app": "collections",
+          "schema_name": "taxon",
+          "user_journey_document_supertype": "finding",
+          "links": {
+            "child_taxons": [
+              {
+                "base_path": "/childcare-parenting/adoption",
+                "content_id": "13bba81c-b2b1-4b13-a3de-b24748977198",
+                "title": "Adoption",
+                "description": "Pay and leave, adopting through your council, inter-agency fees, placement, inspection forms.",
+                "document_type": "taxon",
+                "publishing_app": "content-tagger",
+                "rendering_app": "collections",
+                "schema_name": "taxon",
+                "user_journey_document_supertype": "finding",
+                "links": {
+                  "child_taxons": []
+                }
+              },
+              {
+                "base_path": "/childcare-parenting/surrogacy",
+                "content_id": "b0c0b3c6-6ee2-4fce-9abd-4a73be10c483",
+                "title": "Surrogacy",
+                "description": "Surrogates rights, using a surrogate, parental leave and pay. ",
+                "document_type": "taxon",
+                "publishing_app": "content-tagger",
+                "rendering_app": "collections",
+                "schema_name": "taxon",
+                "user_journey_document_supertype": "finding",
+                "links": {
+                  "child_taxons": []
+                }
+              },
+              {
+                "base_path": "/childcare-parenting/fostering",
+                "content_id": "f40a63ce-ac0c-4102-84d1-f1835cb7daac",
+                "title": "Fostering",
+                "description": "Training, standards, data collection forms, 'staying put' arrangements.",
+                "document_type": "taxon",
+                "publishing_app": "content-tagger",
+                "rendering_app": "collections",
+                "schema_name": "taxon",
+                "user_journey_document_supertype": "finding",
+                "links": {
+                  "child_taxons": []
+                }
+              },
+              {
+                "base_path": "/childcare-parenting/special-guardianship",
+                "content_id": "29698d17-8ce4-46e6-b173-bde2b5977970",
+                "title": "Special guardianship",
+                "description": "Looking after someone else's child.",
+                "document_type": "taxon",
+                "publishing_app": "content-tagger",
+                "rendering_app": "collections",
+                "schema_name": "taxon",
+                "user_journey_document_supertype": "finding",
+                "links": {
+                  "child_taxons": []
+                }
+              },
+              {
+                "base_path": "/childcare-parenting/intercountry-adoption",
+                "content_id": "b42ec0f9-d161-4be6-85c5-bf3933c1cca4",
+                "title": "Intercountry adoption",
+                "description": "Guidance for adoption agencies.",
+                "document_type": "taxon",
+                "publishing_app": "content-tagger",
+                "rendering_app": "collections",
+                "schema_name": "taxon",
+                "user_journey_document_supertype": "finding",
+                "links": {
+                  "child_taxons": []
+                }
+              }
+            ]
+          }
+        },
+        {
+          "base_path": "/childcare-parenting/pregnancy-and-birth",
+          "content_id": "e4335adc-5dc3-47c0-bb27-4998792212eb",
+          "title": "Pregnancy and birth",
+          "description": "Parenting classes and family support, teenage pregnancy.",
+          "document_type": "taxon",
+          "publishing_app": "content-tagger",
+          "rendering_app": "collections",
+          "schema_name": "taxon",
+          "user_journey_document_supertype": "finding",
+          "links": {
+            "child_taxons": [
+              {
+                "base_path": "/childcare-parenting/working-time-off-when-having-a-baby",
+                "content_id": "1bd8be6f-fe5b-4b0b-a780-db1d873951b4",
+                "title": "Working and time off when you're having a baby",
+                "description": "Maternity allowance, paternal pay and leave, Shared Parental Leave (SPL).",
+                "document_type": "taxon",
+                "publishing_app": "content-tagger",
+                "rendering_app": "collections",
+                "schema_name": "taxon",
+                "user_journey_document_supertype": "finding",
+                "links": {
+                  "child_taxons": []
+                }
+              },
+              {
+                "base_path": "/childcare-parenting/financial-support-costs-of-having-a-child",
+                "content_id": "6994997b-2e9e-48ab-80b5-dad4b7ec4839",
+                "title": "Financial support towards the costs of having a child",
+                "description": "Healthy Start, Sure Start Maternity Grant.",
+                "document_type": "taxon",
+                "publishing_app": "content-tagger",
+                "rendering_app": "collections",
+                "schema_name": "taxon",
+                "user_journey_document_supertype": "finding",
+                "links": {
+                  "child_taxons": []
+                }
+              },
+              {
+                "base_path": "/childcare-parenting/register-the-birth-of-a-child",
+                "content_id": "8da62d85-47c0-42df-94c4-eaaeac329671",
+                "title": "Register the birth of a child",
+                "description": "Register a birth abroad or in the UK. Registering a stillbirth.",
+                "document_type": "taxon",
+                "publishing_app": "content-tagger",
+                "rendering_app": "collections",
+                "schema_name": "taxon",
+                "user_journey_document_supertype": "finding",
+                "links": {
+                  "child_taxons": []
+                }
+              }
+            ]
+          }
+        },
+        {
+          "base_path": "/childcare-parenting/childrens-health-and-welfare",
+          "content_id": "2389dfd4-a0c4-4bd2-b7e6-06f465463d22",
+          "title": "Children's health and welfare",
+          "description": "Children's rights, child poverty, mental health, young carers.",
+          "document_type": "taxon",
+          "publishing_app": "content-tagger",
+          "rendering_app": "collections",
+          "schema_name": "taxon",
+          "user_journey_document_supertype": "finding",
+          "links": {
+            "child_taxons": [
+              {
+                "base_path": "/childcare-parenting/help-for-children-with-a-long-term-illness-or-disability",
+                "content_id": "fc2412f2-77d1-4559-96db-b467cda93990",
+                "title": "Help for children with a long-term illness or disability",
+                "description": "Children and families act, disabled children at school. ",
+                "document_type": "taxon",
+                "publishing_app": "content-tagger",
+                "rendering_app": "collections",
+                "schema_name": "taxon",
+                "user_journey_document_supertype": "finding",
+                "links": {
+                  "child_taxons": []
+                }
+              },
+              {
+                "base_path": "/childcare-parenting/mental-health-of-children-and-young-people",
+                "content_id": "0edc28be-da72-4b33-8ecf-e83455eeaced",
+                "title": "Mental health of children and young people",
+                "description": "Behaviour in schools.",
+                "document_type": "taxon",
+                "publishing_app": "content-tagger",
+                "rendering_app": "collections",
+                "schema_name": "taxon",
+                "user_journey_document_supertype": "finding",
+                "links": {
+                  "child_taxons": []
+                }
+              },
+              {
+                "base_path": "/childcare-parenting/young-carers",
+                "content_id": "d0ab64d5-b6c8-4f94-985b-7575cad8c26d",
+                "title": "Young carers",
+                "description": "Improving support, pathfinders programme.",
+                "document_type": "taxon",
+                "publishing_app": "content-tagger",
+                "rendering_app": "collections",
+                "schema_name": "taxon",
+                "user_journey_document_supertype": "finding",
+                "links": {
+                  "child_taxons": []
+                }
+              },
+              {
+                "base_path": "/childcare-parenting/childrens-rights",
+                "content_id": "4f72853c-d9ea-4b34-a986-2f62359e9e40",
+                "title": "Children's rights",
+                "description": "Advocacy for children, leaving children at home.",
+                "document_type": "taxon",
+                "publishing_app": "content-tagger",
+                "rendering_app": "collections",
+                "schema_name": "taxon",
+                "user_journey_document_supertype": "finding",
+                "links": {
+                  "child_taxons": []
+                }
+              },
+              {
+                "base_path": "/childcare-parenting/child-poverty",
+                "content_id": "eb6c325f-09b7-4873-86f0-6b2eacc4d27f",
+                "title": "Child poverty",
+                "description": "Advice and training for practitioners, basket of indicators.",
+                "document_type": "taxon",
+                "publishing_app": "content-tagger",
+                "rendering_app": "collections",
+                "schema_name": "taxon",
+                "user_journey_document_supertype": "finding",
+                "links": {
+                  "child_taxons": []
+                }
+              },
+              {
+                "base_path": "/childcare-parenting/support-for-children-with-send",
+                "content_id": "44509d44-824f-40a2-babe-6388b6136b7b",
+                "title": "Support for children with special educational needs and disabilities (SEND)",
+                "description": "Assessments, guide for health professionals, reform funding for local authorities, surveys.",
+                "document_type": "taxon",
+                "publishing_app": "content-tagger",
+                "rendering_app": "collections",
+                "schema_name": "taxon",
+                "user_journey_document_supertype": "finding",
+                "links": {
+                  "child_taxons": []
+                }
+              }
+            ]
+          }
+        },
+        {
+          "base_path": "/childcare-parenting/divorce-separation-and-legal-issues",
+          "content_id": "1423ec9f-d62c-40f7-b10e-a2bdf020d8b7",
+          "title": "Divorce, separation and legal issues",
+          "description": "Child maintenance, disagreements about parentage, child custody.",
+          "document_type": "taxon",
+          "publishing_app": "content-tagger",
+          "rendering_app": "collections",
+          "schema_name": "taxon",
+          "user_journey_document_supertype": "finding",
+          "links": {
+            "child_taxons": [
+              {
+                "base_path": "/childcare-parenting/disagreements-about-parentage",
+                "content_id": "237b2e72-c465-42fe-9293-8b6af21713c0",
+                "title": "Disagreements about parentage",
+                "description": "Child maintenance service, child support agency.",
+                "document_type": "taxon",
+                "publishing_app": "content-tagger",
+                "rendering_app": "collections",
+                "schema_name": "taxon",
+                "user_journey_document_supertype": "finding",
+                "links": {
+                  "child_taxons": []
+                }
+              },
+              {
+                "base_path": "/childcare-parenting/child-custody",
+                "content_id": "9ed56732-8600-493e-8467-295233529718",
+                "title": "Child custody",
+                "description": "Arrange custody, abducted children, cross-border child protection.",
+                "document_type": "taxon",
+                "publishing_app": "content-tagger",
+                "rendering_app": "collections",
+                "schema_name": "taxon",
+                "user_journey_document_supertype": "finding",
+                "links": {
+                  "child_taxons": []
+                }
+              },
+              {
+                "base_path": "/childcare-parenting/child-maintenance",
+                "content_id": "902af4ff-4a3b-4860-932a-f7d9a47c337e",
+                "title": "Child maintenance",
+                "description": "Arrange child maintenance, calculator.",
+                "document_type": "taxon",
+                "publishing_app": "content-tagger",
+                "rendering_app": "collections",
+                "schema_name": "taxon",
+                "user_journey_document_supertype": "finding",
+                "links": {
+                  "child_taxons": []
+                }
+              }
+            ]
+          }
+        },
+        {
+          "base_path": "/childcare-parenting/financial-help-if-you-have-children",
+          "content_id": "a44b1c68-807c-45fe-bc7b-a47586617863",
+          "title": "Financial help if you have children",
+          "description": "Child benefit, tax credits, financial support for childcare.",
+          "document_type": "taxon",
+          "publishing_app": "content-tagger",
+          "rendering_app": "collections",
+          "schema_name": "taxon",
+          "user_journey_document_supertype": "finding",
+          "links": {
+            "child_taxons": [
+              {
+                "base_path": "/childcare-parenting/financial-help-when-having-a-baby",
+                "content_id": "090f8b0b-02f6-446b-b2ec-6000d7cd8322",
+                "title": "Financial help when having a baby",
+                "description": "Sure start maternity grant, maternity and paternity allowance and leave, shared parental leave.",
+                "document_type": "taxon",
+                "publishing_app": "content-tagger",
+                "rendering_app": "collections",
+                "schema_name": "taxon",
+                "user_journey_document_supertype": "finding",
+                "links": {
+                  "child_taxons": []
+                }
+              },
+              {
+                "base_path": "/childcare-parenting/tax-credits-if-you-have-children",
+                "content_id": "65a25d2c-a0e5-4283-921d-c928babfb6e4",
+                "title": "Tax credits if you have children",
+                "description": "Claim child tax credit, renew, overpayments, payment dates, working tax credit.",
+                "document_type": "taxon",
+                "publishing_app": "content-tagger",
+                "rendering_app": "collections",
+                "schema_name": "taxon",
+                "user_journey_document_supertype": "finding",
+                "links": {
+                  "child_taxons": []
+                }
+              },
+              {
+                "base_path": "/childcare-parenting/child-benefit",
+                "content_id": "c73891d9-1ead-4075-8681-8189de727cb9",
+                "title": "Child benefit",
+                "description": "Claim child benefit, rates, tax calculator, guardians allowance. ",
+                "document_type": "taxon",
+                "publishing_app": "content-tagger",
+                "rendering_app": "collections",
+                "schema_name": "taxon",
+                "user_journey_document_supertype": "finding",
+                "links": {
+                  "child_taxons": []
+                }
+              },
+              {
+                "base_path": "/childcare-parenting/savings-accounts-for-children",
+                "content_id": "7966b917-60ea-4276-981e-84c59dfc5f7a",
+                "title": "Savings accounts for children",
+                "description": "Individual savings accounts, interest, tax.",
+                "document_type": "taxon",
+                "publishing_app": "content-tagger",
+                "rendering_app": "collections",
+                "schema_name": "taxon",
+                "user_journey_document_supertype": "finding",
+                "links": {
+                  "child_taxons": []
+                }
+              },
+              {
+                "base_path": "/childcare-parenting/financial-help-if-you-have-a-disabled-child",
+                "content_id": "7a2b6588-d734-4057-8d2f-f80a47123f17",
+                "title": "Financial help if you have a disabled child",
+                "description": "Childrens disability living allowance, facilities grants. ",
+                "document_type": "taxon",
+                "publishing_app": "content-tagger",
+                "rendering_app": "collections",
+                "schema_name": "taxon",
+                "user_journey_document_supertype": "finding",
+                "links": {
+                  "child_taxons": []
+                }
+              },
+              {
+                "base_path": "/childcare-parenting/financial-help-if-youre-a-student-with-children",
+                "content_id": "9797d693-65f2-4e74-b652-2dae0ce7e4d4",
+                "title": "Financial help if you're a student with children",
+                "description": "Childcare grant, care to learn, learning allowance. ",
+                "document_type": "taxon",
+                "publishing_app": "content-tagger",
+                "rendering_app": "collections",
+                "schema_name": "taxon",
+                "user_journey_document_supertype": "finding",
+                "links": {
+                  "child_taxons": []
+                }
+              },
+              {
+                "base_path": "/childcare-parenting/financial-support-for-childcare",
+                "content_id": "6391a4bc-6109-4da4-b311-f78954334969",
+                "title": "Financial support for childcare",
+                "description": "Childcare calculator, childcare grant, tax credits, help with costs. ",
+                "document_type": "taxon",
+                "publishing_app": "content-tagger",
+                "rendering_app": "collections",
+                "schema_name": "taxon",
+                "user_journey_document_supertype": "finding",
+                "links": {
+                  "child_taxons": []
+                }
+              }
+            ]
+          }
+        },
+        {
+          "base_path": "/childcare-parenting/childcare-and-early-years",
+          "content_id": "f1d9c348-5c5e-4fc6-9172-13a62537d3ae",
+          "title": "Childcare and early years",
+          "description": "Finding childcare, running a childcare business, financial support.",
+          "document_type": "taxon",
+          "publishing_app": "content-tagger",
+          "rendering_app": "collections",
+          "schema_name": "taxon",
+          "user_journey_document_supertype": "finding",
+          "links": {
+            "child_taxons": [
+              {
+                "base_path": "/childcare-parenting/finding-childcare",
+                "content_id": "62562899-fed3-4876-ba61-80264d140009",
+                "title": "Finding childcare",
+                "description": "Arrange childcare and after-school care.",
+                "document_type": "taxon",
+                "publishing_app": "content-tagger",
+                "rendering_app": "collections",
+                "schema_name": "taxon",
+                "user_journey_document_supertype": "finding",
+                "links": {
+                  "child_taxons": []
+                }
+              },
+              {
+                "base_path": "/childcare-parenting/data-collection-for-early-years-and-childcare",
+                "content_id": "4713d510-9dd1-479f-a2f3-9b2ec5cde0e3",
+                "title": "Data collection for early years and childcare",
+                "description": "Census, foundation stage profile return.",
+                "document_type": "taxon",
+                "publishing_app": "content-tagger",
+                "rendering_app": "collections",
+                "schema_name": "taxon",
+                "user_journey_document_supertype": "finding",
+                "links": {
+                  "child_taxons": [
+                    {
+                      "base_path": "/childcare-parenting/early-years-census",
+                      "content_id": "5a73303d-0c74-4115-9c3e-7d0e925cb1ae",
+                      "title": "Early years census",
+                      "description": "Guide, technical specification.",
+                      "document_type": "taxon",
+                      "publishing_app": "content-tagger",
+                      "rendering_app": "collections",
+                      "schema_name": "taxon",
+                      "user_journey_document_supertype": "finding",
+                      "links": {
+                        "child_taxons": []
+                      }
+                    },
+                    {
+                      "base_path": "/childcare-parenting/early-years-foundation-stage-profile-return",
+                      "content_id": "84230b48-93db-45f9-a374-0a82bba90f4e",
+                      "title": "Early years foundation stage profile return",
+                      "description": "Return guide, technical specification.",
+                      "document_type": "taxon",
+                      "publishing_app": "content-tagger",
+                      "rendering_app": "collections",
+                      "schema_name": "taxon",
+                      "user_journey_document_supertype": "finding",
+                      "links": {
+                        "child_taxons": []
+                      }
+                    }
+                  ]
+                }
+              },
+              {
+                "base_path": "/childcare-parenting/providing-childcare",
+                "content_id": "18cb575a-45a0-4ab8-8bff-12c48a2ee8d4",
+                "title": "Providing childcare",
+                "description": "Become a childcare provider, early years curriculum, early years funding. ",
+                "document_type": "taxon",
+                "publishing_app": "content-tagger",
+                "rendering_app": "collections",
+                "schema_name": "taxon",
+                "user_journey_document_supertype": "finding",
+                "links": {
+                  "child_taxons": [
+                    {
+                      "base_path": "/childcare-parenting/childminding",
+                      "content_id": "61842205-392f-43f8-a612-45310e8ab454",
+                      "title": "Childminding",
+                      "description": "Register as an early years childminder, childminder regulations, childcare inspections. ",
+                      "document_type": "taxon",
+                      "publishing_app": "content-tagger",
+                      "rendering_app": "collections",
+                      "schema_name": "taxon",
+                      "user_journey_document_supertype": "finding",
+                      "links": {
+                        "child_taxons": []
+                      }
+                    },
+                    {
+                      "base_path": "/childcare-parenting/recruiting-and-managing-early-years-staff",
+                      "content_id": "6a1688d6-c0ed-4b2f-a5ea-aac3748c8394",
+                      "title": "Recruiting and managing early years staff",
+                      "description": "Initial teacher training, qualifications criteria.",
+                      "document_type": "taxon",
+                      "publishing_app": "content-tagger",
+                      "rendering_app": "collections",
+                      "schema_name": "taxon",
+                      "user_journey_document_supertype": "finding",
+                      "links": {
+                        "child_taxons": []
+                      }
+                    },
+                    {
+                      "base_path": "/childcare-parenting/pre-schools-and-nurseries",
+                      "content_id": "9b32bfef-a79a-4253-99b5-a37b7d4d24f2",
+                      "title": "Pre-schools and nurseries",
+                      "description": "Childcare register inspections.",
+                      "document_type": "taxon",
+                      "publishing_app": "content-tagger",
+                      "rendering_app": "collections",
+                      "schema_name": "taxon",
+                      "user_journey_document_supertype": "finding",
+                      "links": {
+                        "child_taxons": []
+                      }
+                    },
+                    {
+                      "base_path": "/childcare-parenting/funding-and-finance-for-childcare-providers",
+                      "content_id": "89b2ca59-0a37-4576-b226-95bde1e9efc4",
+                      "title": "Funding and finance for childcare providers",
+                      "description": "Pupil premium, early years pupil premium, early education enitlement. ",
+                      "document_type": "taxon",
+                      "publishing_app": "content-tagger",
+                      "rendering_app": "collections",
+                      "schema_name": "taxon",
+                      "user_journey_document_supertype": "finding",
+                      "links": {
+                        "child_taxons": []
+                      }
+                    },
+                    {
+                      "base_path": "/childcare-parenting/childrens-centres",
+                      "content_id": "932cd756-d3ae-4f9d-a7bb-8b7178dc9adb",
+                      "title": "Children's centres",
+                      "description": "Inspections, Sure Start.",
+                      "document_type": "taxon",
+                      "publishing_app": "content-tagger",
+                      "rendering_app": "collections",
+                      "schema_name": "taxon",
+                      "user_journey_document_supertype": "finding",
+                      "links": {
+                        "child_taxons": []
+                      }
+                    },
+                    {
+                      "base_path": "/childcare-parenting/Early-years-curriculum-0-to-5",
+                      "content_id": "b508d8eb-de70-4e08-b7d9-9e4a9f5bedae",
+                      "title": "Early years curriculum (0 to 5)",
+                      "description": "Early Years Foundation Stage.",
+                      "document_type": "taxon",
+                      "publishing_app": "content-tagger",
+                      "rendering_app": "collections",
+                      "schema_name": "taxon",
+                      "user_journey_document_supertype": "finding",
+                      "links": {
+                        "child_taxons": []
+                      }
+                    },
+                    {
+                      "base_path": "/childcare-parenting/becoming-a-childcare-provider",
+                      "content_id": "39e60ce9-5b21-49e9-919f-2cf3ffa4b075",
+                      "title": "Becoming a childcare provider",
+                      "description": "Register with Ofsted, agencies, children's social care providers, financial references, DBS checks.",
+                      "document_type": "taxon",
+                      "publishing_app": "content-tagger",
+                      "rendering_app": "collections",
+                      "schema_name": "taxon",
+                      "user_journey_document_supertype": "finding",
+                      "links": {
+                        "child_taxons": []
+                      }
+                    },
+                    {
+                      "base_path": "/childcare-parenting/local-authority-early-years-funding-and-obligations",
+                      "content_id": "1da1c700-cef8-45c4-9bb7-11a4b0003e10",
+                      "title": "Local authority early years funding and obligations",
+                      "description": "Entitlement guide, providing early education and childcare. ",
+                      "document_type": "taxon",
+                      "publishing_app": "content-tagger",
+                      "rendering_app": "collections",
+                      "schema_name": "taxon",
+                      "user_journey_document_supertype": "finding",
+                      "links": {
+                        "child_taxons": []
+                      }
+                    },
+                    {
+                      "base_path": "/childcare-parenting/performance-and-inspection-of-childcare-providers",
+                      "content_id": "b52d05ab-bc36-4a68-9bbf-63417788af3c",
+                      "title": "Performance and inspection of childcare providers",
+                      "description": "Early years information, inspection guidance, Ofsted registration fee. ",
+                      "document_type": "taxon",
+                      "publishing_app": "content-tagger",
+                      "rendering_app": "collections",
+                      "schema_name": "taxon",
+                      "user_journey_document_supertype": "finding",
+                      "links": {
+                        "child_taxons": []
+                      }
+                    },
+                    {
+                      "base_path": "/childcare-parenting/qualifications-training-and-professional-development-for-childcare-providers",
+                      "content_id": "f002c7d4-9d6c-4ad8-8174-28ec7d4510fe",
+                      "title": "Qualifications, training and professional development for childcare providers",
+                      "description": "Qualifications criteria.",
+                      "document_type": "taxon",
+                      "publishing_app": "content-tagger",
+                      "rendering_app": "collections",
+                      "schema_name": "taxon",
+                      "user_journey_document_supertype": "finding",
+                      "links": {
+                        "child_taxons": []
+                      }
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        },
+        {
+          "base_path": "/childcare-parenting/youth-employment-and-social-issues",
+          "content_id": "43fcdde6-59c5-487f-a969-a046b334cbec",
+          "title": "Youth employment and social issues",
+          "description": "Developing social and emotional skills, improving outcomes, best practice for commissioning.",
+          "document_type": "taxon",
+          "publishing_app": "content-tagger",
+          "rendering_app": "collections",
+          "schema_name": "taxon",
+          "user_journey_document_supertype": "finding",
+          "links": {
+            "child_taxons": []
+          }
+        }
+      ]
+    }
+  },
+  {
+    "base_path": "/childcare-parenting/safeguarding-and-social-care-for-children",
+    "content_id": "20eb4e84-98ee-404b-a4bd-fe8a36d5d71d",
+    "title": "Safeguarding and social care for children",
+    "description": "Child protection, children in care, become a social care provide. ",
+    "document_type": "taxon",
+    "publishing_app": "content-tagger",
+    "rendering_app": "collections",
+    "schema_name": "taxon",
+    "user_journey_document_supertype": "finding",
+    "links": {
+      "child_taxons": [
+        {
+          "base_path": "/childcare-parenting/child-and-family-social-work",
+          "content_id": "df68fd4e-8e6f-4473-a24a-6033d65fb1d0",
+          "title": "Child and family social work",
+          "description": "Knowledge and skills statements. Inter-agency safeguarding. Guidance on becoming a social worker.",
+          "document_type": "taxon",
+          "publishing_app": "content-tagger",
+          "rendering_app": "collections",
+          "schema_name": "taxon",
+          "user_journey_document_supertype": "finding",
+          "links": {
+            "child_taxons": []
+          }
+        },
+        {
+          "base_path": "/education/safeguarding-child-protection",
+          "content_id": "5af6180c-d5db-4cc1-a68e-7bd066908132",
+          "title": "Safeguarding and child protection",
+          "description": "Prevent neglect and abuse, homeless children, data collection. ",
+          "document_type": "taxon",
+          "publishing_app": "content-tagger",
+          "rendering_app": "collections",
+          "schema_name": "taxon",
+          "user_journey_document_supertype": "finding",
+          "links": {
+            "child_taxons": [
+              {
+                "base_path": "/childcare-parenting/child-abduction-cross-border-child-protection",
+                "content_id": "d58bd4de-3fee-4953-9654-7551333eebf1",
+                "title": "Child abduction and cross-border child protection",
+                "description": "International child protection cases. Guidance on working with foreign agencies.",
+                "document_type": "taxon",
+                "publishing_app": "content-tagger",
+                "rendering_app": "collections",
+                "schema_name": "taxon",
+                "user_journey_document_supertype": "finding",
+                "links": {
+                  "child_taxons": []
+                }
+              },
+              {
+                "base_path": "/childcare-parenting/data-collection-safeguarding-child-protection",
+                "content_id": "d36f331f-ef4e-48e2-81e5-c4ed6c94a1f9",
+                "title": "Data collection for safeguarding and child protection",
+                "description": "Children in need census collect reports. Child death data collection.",
+                "document_type": "taxon",
+                "publishing_app": "content-tagger",
+                "rendering_app": "collections",
+                "schema_name": "taxon",
+                "user_journey_document_supertype": "finding",
+                "links": {
+                  "child_taxons": []
+                }
+              },
+              {
+                "base_path": "/childcare-parenting/preventing-neglect-abuse-and-exploitation",
+                "content_id": "47fbdb87-b4ff-432a-a4cf-a2f2468ff6d4",
+                "title": "Preventing neglect, abuse and exploitation",
+                "description": "Online safety. Reporting and dealing with allegations of abuse. Female genital mutiliation (FGM).",
+                "document_type": "taxon",
+                "publishing_app": "content-tagger",
+                "rendering_app": "collections",
+                "schema_name": "taxon",
+                "user_journey_document_supertype": "finding",
+                "links": {
+                  "child_taxons": []
+                }
+              },
+              {
+                "base_path": "/childcare-parenting/refugee-runaway-and-homeless-children",
+                "content_id": "fbe2ce17-9ee6-4dcb-a523-ae5383d2cf4c",
+                "title": "Refugee, runaway and homeless children",
+                "description": "Guidance to stop children going missing, and to protect those who do.",
+                "document_type": "taxon",
+                "publishing_app": "content-tagger",
+                "rendering_app": "collections",
+                "schema_name": "taxon",
+                "user_journey_document_supertype": "finding",
+                "links": {
+                  "child_taxons": []
+                }
+              },
+              {
+                "base_path": "/childcare-parenting/serious-case-reviews",
+                "content_id": "e626b2fd-203e-4e2e-b8a5-121896ae22e7",
+                "title": "Serious case reviews",
+                "description": "Improving safeguarding after the serious injury or death of a child.",
+                "document_type": "taxon",
+                "publishing_app": "content-tagger",
+                "rendering_app": "collections",
+                "schema_name": "taxon",
+                "user_journey_document_supertype": "finding",
+                "links": {
+                  "child_taxons": []
+                }
+              }
+            ]
+          }
+        },
+        {
+          "base_path": "/childcare-parenting/looked-after-children-children-in-care",
+          "content_id": "431a7fac-a2e8-4ffc-8fc7-bab10fc5e6d4",
+          "title": "Looked-after children and children in care",
+          "description": "Children's homes, data collection, children leaving care. ",
+          "document_type": "taxon",
+          "publishing_app": "content-tagger",
+          "rendering_app": "collections",
+          "schema_name": "taxon",
+          "user_journey_document_supertype": "finding",
+          "links": {
+            "child_taxons": [
+              {
+                "base_path": "/childcare-parenting/childrens-homes-and-other-accommodation",
+                "content_id": "50904cbc-3cde-4a3b-92ba-b75117671574",
+                "title": "Children's homes and other accommodation",
+                "description": "Securing a place. Regulations and quality standards, children's privacy and confidentiality.",
+                "document_type": "taxon",
+                "publishing_app": "content-tagger",
+                "rendering_app": "collections",
+                "schema_name": "taxon",
+                "user_journey_document_supertype": "finding",
+                "links": {
+                  "child_taxons": []
+                }
+              },
+              {
+                "base_path": "/childcare-parenting/children-and-young-people-leaving-care",
+                "content_id": "d5c3d032-2c12-4bb3-8340-3cc5084ccba7",
+                "title": "Children and young people leaving care",
+                "description": "Care leavers' charter, council responsibilities. Staying put arrangements.",
+                "document_type": "taxon",
+                "publishing_app": "content-tagger",
+                "rendering_app": "collections",
+                "schema_name": "taxon",
+                "user_journey_document_supertype": "finding",
+                "links": {
+                  "child_taxons": []
+                }
+              },
+              {
+                "base_path": "/childcare-parenting/data-collection-for-looked-after-children",
+                "content_id": "c359fa76-88ff-4298-817e-5cf974473853",
+                "title": "Data collection for looked-after children",
+                "description": "Submitting data. Validation rules, technical specification.",
+                "document_type": "taxon",
+                "publishing_app": "content-tagger",
+                "rendering_app": "collections",
+                "schema_name": "taxon",
+                "user_journey_document_supertype": "finding",
+                "links": {
+                  "child_taxons": []
+                }
+              }
+            ]
+          }
+        },
+        {
+          "base_path": "/childcare-parenting/childrens-social-care-providers",
+          "content_id": "454b3d57-870e-4691-a700-abbf7d883c34",
+          "title": "Children's social care providers",
+          "description": "Registering, inspections, complaints, roles and responsibilities. Children's Act 1989 court orders.",
+          "document_type": "taxon",
+          "publishing_app": "content-tagger",
+          "rendering_app": "collections",
+          "schema_name": "taxon",
+          "user_journey_document_supertype": "finding",
+          "links": {
+            "child_taxons": [
+              {
+                "base_path": "/childcare-parenting/inspection-of-childrens-social-care-providers",
+                "content_id": "689bb0dd-bd50-42e0-9195-cfb020bc3ee7",
+                "title": "Inspection of children's social care providers",
+                "description": "Improvement notices, completing an evidence base, children's homes.",
+                "document_type": "taxon",
+                "publishing_app": "content-tagger",
+                "rendering_app": "collections",
+                "schema_name": "taxon",
+                "user_journey_document_supertype": "finding",
+                "links": {
+                  "child_taxons": []
+                }
+              },
+              {
+                "base_path": "/childcare-parenting/becoming-a-childrens-social-care-provider",
+                "content_id": "45a65707-11c7-4e58-88b7-164f83d073e6",
+                "title": "Becoming a children's social care provider",
+                "description": "Application checklist, assessment questionnaire. How to register.",
+                "document_type": "taxon",
+                "publishing_app": "content-tagger",
+                "rendering_app": "collections",
+                "schema_name": "taxon",
+                "user_journey_document_supertype": "finding",
+                "links": {
+                  "child_taxons": []
+                }
+              },
+              {
+                "base_path": "/childcare-parenting/social-care-provider-complaints",
+                "content_id": "49043bab-0075-414b-969b-b144539eef05",
+                "title": "Social care provider complaints",
+                "description": "Raise a complaint or concern about a social care provider.",
+                "document_type": "taxon",
+                "publishing_app": "content-tagger",
+                "rendering_app": "collections",
+                "schema_name": "taxon",
+                "user_journey_document_supertype": "finding",
+                "links": {
+                  "child_taxons": []
+                }
+              }
+            ]
+          }
+        }
+      ],
+      "parent_taxons": [
+        {
+          "base_path": "/childcare-parenting",
+          "content_id": "206b7f3a-49b5-476f-af0f-fd27e2a68473",
+          "title": "Parenting, childcare and children's services ",
+          "description": "Health and welfare, financial help, finding a school, adoption, looked-after children, safeguarding.",
+          "document_type": "taxon",
+          "publishing_app": "content-tagger",
+          "rendering_app": "collections",
+          "schema_name": "taxon",
+          "user_journey_document_supertype": "finding",
+          "links": {}
+        }
+      ]
+    }
+  },
+  {
+    "base_path": "/childcare-parenting/child-and-family-social-work",
+    "content_id": "df68fd4e-8e6f-4473-a24a-6033d65fb1d0",
+    "title": "Child and family social work",
+    "description": "Knowledge and skills statements. Inter-agency safeguarding. Guidance on becoming a social worker.",
+    "document_type": "taxon",
+    "publishing_app": "content-tagger",
+    "rendering_app": "collections",
+    "schema_name": "taxon",
+    "user_journey_document_supertype": "finding",
+    "links": {
+      "child_taxons": [],
+      "parent_taxons": [
+        {
+          "base_path": "/childcare-parenting/safeguarding-and-social-care-for-children",
+          "content_id": "20eb4e84-98ee-404b-a4bd-fe8a36d5d71d",
+          "title": "Safeguarding and social care for children",
+          "description": "Child protection, children in care, become a social care provide. ",
+          "document_type": "taxon",
+          "publishing_app": "content-tagger",
+          "rendering_app": "collections",
+          "schema_name": "taxon",
+          "user_journey_document_supertype": "finding",
+          "links": {
+            "parent_taxons": [
+              {
+                "base_path": "/childcare-parenting",
+                "content_id": "206b7f3a-49b5-476f-af0f-fd27e2a68473",
+                "title": "Parenting, childcare and children's services ",
+                "description": "Health and welfare, financial help, finding a school, adoption, looked-after children, safeguarding.",
+                "document_type": "taxon",
+                "publishing_app": "content-tagger",
+                "rendering_app": "collections",
+                "schema_name": "taxon",
+                "user_journey_document_supertype": "finding",
+                "links": {}
+              }
+            ]
+          }
+        }
+      ]
+    }
+  },
+  {
+    "base_path": "/education/safeguarding-child-protection",
+    "content_id": "5af6180c-d5db-4cc1-a68e-7bd066908132",
+    "title": "Safeguarding and child protection",
+    "description": "Prevent neglect and abuse, homeless children, data collection. ",
+    "document_type": "taxon",
+    "publishing_app": "content-tagger",
+    "rendering_app": "collections",
+    "schema_name": "taxon",
+    "user_journey_document_supertype": "finding",
+    "links": {
+      "child_taxons": [
+        {
+          "base_path": "/childcare-parenting/child-abduction-cross-border-child-protection",
+          "content_id": "d58bd4de-3fee-4953-9654-7551333eebf1",
+          "title": "Child abduction and cross-border child protection",
+          "description": "International child protection cases. Guidance on working with foreign agencies.",
+          "document_type": "taxon",
+          "publishing_app": "content-tagger",
+          "rendering_app": "collections",
+          "schema_name": "taxon",
+          "user_journey_document_supertype": "finding",
+          "links": {
+            "child_taxons": []
+          }
+        },
+        {
+          "base_path": "/childcare-parenting/data-collection-safeguarding-child-protection",
+          "content_id": "d36f331f-ef4e-48e2-81e5-c4ed6c94a1f9",
+          "title": "Data collection for safeguarding and child protection",
+          "description": "Children in need census collect reports. Child death data collection.",
+          "document_type": "taxon",
+          "publishing_app": "content-tagger",
+          "rendering_app": "collections",
+          "schema_name": "taxon",
+          "user_journey_document_supertype": "finding",
+          "links": {
+            "child_taxons": []
+          }
+        },
+        {
+          "base_path": "/childcare-parenting/preventing-neglect-abuse-and-exploitation",
+          "content_id": "47fbdb87-b4ff-432a-a4cf-a2f2468ff6d4",
+          "title": "Preventing neglect, abuse and exploitation",
+          "description": "Online safety. Reporting and dealing with allegations of abuse. Female genital mutiliation (FGM).",
+          "document_type": "taxon",
+          "publishing_app": "content-tagger",
+          "rendering_app": "collections",
+          "schema_name": "taxon",
+          "user_journey_document_supertype": "finding",
+          "links": {
+            "child_taxons": []
+          }
+        },
+        {
+          "base_path": "/childcare-parenting/refugee-runaway-and-homeless-children",
+          "content_id": "fbe2ce17-9ee6-4dcb-a523-ae5383d2cf4c",
+          "title": "Refugee, runaway and homeless children",
+          "description": "Guidance to stop children going missing, and to protect those who do.",
+          "document_type": "taxon",
+          "publishing_app": "content-tagger",
+          "rendering_app": "collections",
+          "schema_name": "taxon",
+          "user_journey_document_supertype": "finding",
+          "links": {
+            "child_taxons": []
+          }
+        },
+        {
+          "base_path": "/childcare-parenting/serious-case-reviews",
+          "content_id": "e626b2fd-203e-4e2e-b8a5-121896ae22e7",
+          "title": "Serious case reviews",
+          "description": "Improving safeguarding after the serious injury or death of a child.",
+          "document_type": "taxon",
+          "publishing_app": "content-tagger",
+          "rendering_app": "collections",
+          "schema_name": "taxon",
+          "user_journey_document_supertype": "finding",
+          "links": {
+            "child_taxons": []
+          }
+        }
+      ],
+      "parent_taxons": [
+        {
+          "base_path": "/childcare-parenting/safeguarding-and-social-care-for-children",
+          "content_id": "20eb4e84-98ee-404b-a4bd-fe8a36d5d71d",
+          "title": "Safeguarding and social care for children",
+          "description": "Child protection, children in care, become a social care provide. ",
+          "document_type": "taxon",
+          "publishing_app": "content-tagger",
+          "rendering_app": "collections",
+          "schema_name": "taxon",
+          "user_journey_document_supertype": "finding",
+          "links": {
+            "parent_taxons": [
+              {
+                "base_path": "/childcare-parenting",
+                "content_id": "206b7f3a-49b5-476f-af0f-fd27e2a68473",
+                "title": "Parenting, childcare and children's services ",
+                "description": "Health and welfare, financial help, finding a school, adoption, looked-after children, safeguarding.",
+                "document_type": "taxon",
+                "publishing_app": "content-tagger",
+                "rendering_app": "collections",
+                "schema_name": "taxon",
+                "user_journey_document_supertype": "finding",
+                "links": {}
+              }
+            ]
+          }
+        }
+      ]
+    }
+  },
+  {
+    "base_path": "/childcare-parenting/child-abduction-cross-border-child-protection",
+    "content_id": "d58bd4de-3fee-4953-9654-7551333eebf1",
+    "title": "Child abduction and cross-border child protection",
+    "description": "International child protection cases. Guidance on working with foreign agencies.",
+    "document_type": "taxon",
+    "publishing_app": "content-tagger",
+    "rendering_app": "collections",
+    "schema_name": "taxon",
+    "user_journey_document_supertype": "finding",
+    "links": {
+      "child_taxons": [],
+      "parent_taxons": [
+        {
+          "base_path": "/education/safeguarding-child-protection",
+          "content_id": "5af6180c-d5db-4cc1-a68e-7bd066908132",
+          "title": "Safeguarding and child protection",
+          "description": "Prevent neglect and abuse, homeless children, data collection. ",
+          "document_type": "taxon",
+          "publishing_app": "content-tagger",
+          "rendering_app": "collections",
+          "schema_name": "taxon",
+          "user_journey_document_supertype": "finding",
+          "links": {
+            "parent_taxons": [
+              {
+                "base_path": "/childcare-parenting/safeguarding-and-social-care-for-children",
+                "content_id": "20eb4e84-98ee-404b-a4bd-fe8a36d5d71d",
+                "title": "Safeguarding and social care for children",
+                "description": "Child protection, children in care, become a social care provide. ",
+                "document_type": "taxon",
+                "publishing_app": "content-tagger",
+                "rendering_app": "collections",
+                "schema_name": "taxon",
+                "user_journey_document_supertype": "finding",
+                "links": {
+                  "parent_taxons": [
+                    {
+                      "base_path": "/childcare-parenting",
+                      "content_id": "206b7f3a-49b5-476f-af0f-fd27e2a68473",
+                      "title": "Parenting, childcare and children's services ",
+                      "description": "Health and welfare, financial help, finding a school, adoption, looked-after children, safeguarding.",
+                      "document_type": "taxon",
+                      "publishing_app": "content-tagger",
+                      "rendering_app": "collections",
+                      "schema_name": "taxon",
+                      "user_journey_document_supertype": "finding",
+                      "links": {}
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        }
+      ]
+    }
+  },
+  {
+    "base_path": "/childcare-parenting/data-collection-safeguarding-child-protection",
+    "content_id": "d36f331f-ef4e-48e2-81e5-c4ed6c94a1f9",
+    "title": "Data collection for safeguarding and child protection",
+    "description": "Children in need census collect reports. Child death data collection.",
+    "document_type": "taxon",
+    "publishing_app": "content-tagger",
+    "rendering_app": "collections",
+    "schema_name": "taxon",
+    "user_journey_document_supertype": "finding",
+    "links": {
+      "child_taxons": [],
+      "parent_taxons": [
+        {
+          "base_path": "/education/safeguarding-child-protection",
+          "content_id": "5af6180c-d5db-4cc1-a68e-7bd066908132",
+          "title": "Safeguarding and child protection",
+          "description": "Prevent neglect and abuse, homeless children, data collection. ",
+          "document_type": "taxon",
+          "publishing_app": "content-tagger",
+          "rendering_app": "collections",
+          "schema_name": "taxon",
+          "user_journey_document_supertype": "finding",
+          "links": {
+            "parent_taxons": [
+              {
+                "base_path": "/childcare-parenting/safeguarding-and-social-care-for-children",
+                "content_id": "20eb4e84-98ee-404b-a4bd-fe8a36d5d71d",
+                "title": "Safeguarding and social care for children",
+                "description": "Child protection, children in care, become a social care provide. ",
+                "document_type": "taxon",
+                "publishing_app": "content-tagger",
+                "rendering_app": "collections",
+                "schema_name": "taxon",
+                "user_journey_document_supertype": "finding",
+                "links": {
+                  "parent_taxons": [
+                    {
+                      "base_path": "/childcare-parenting",
+                      "content_id": "206b7f3a-49b5-476f-af0f-fd27e2a68473",
+                      "title": "Parenting, childcare and children's services ",
+                      "description": "Health and welfare, financial help, finding a school, adoption, looked-after children, safeguarding.",
+                      "document_type": "taxon",
+                      "publishing_app": "content-tagger",
+                      "rendering_app": "collections",
+                      "schema_name": "taxon",
+                      "user_journey_document_supertype": "finding",
+                      "links": {}
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        }
+      ]
+    }
+  },
+  {
+    "base_path": "/childcare-parenting/preventing-neglect-abuse-and-exploitation",
+    "content_id": "47fbdb87-b4ff-432a-a4cf-a2f2468ff6d4",
+    "title": "Preventing neglect, abuse and exploitation",
+    "description": "Online safety. Reporting and dealing with allegations of abuse. Female genital mutiliation (FGM).",
+    "document_type": "taxon",
+    "publishing_app": "content-tagger",
+    "rendering_app": "collections",
+    "schema_name": "taxon",
+    "user_journey_document_supertype": "finding",
+    "links": {
+      "child_taxons": [],
+      "parent_taxons": [
+        {
+          "base_path": "/education/safeguarding-child-protection",
+          "content_id": "5af6180c-d5db-4cc1-a68e-7bd066908132",
+          "title": "Safeguarding and child protection",
+          "description": "Prevent neglect and abuse, homeless children, data collection. ",
+          "document_type": "taxon",
+          "publishing_app": "content-tagger",
+          "rendering_app": "collections",
+          "schema_name": "taxon",
+          "user_journey_document_supertype": "finding",
+          "links": {
+            "parent_taxons": [
+              {
+                "base_path": "/childcare-parenting/safeguarding-and-social-care-for-children",
+                "content_id": "20eb4e84-98ee-404b-a4bd-fe8a36d5d71d",
+                "title": "Safeguarding and social care for children",
+                "description": "Child protection, children in care, become a social care provide. ",
+                "document_type": "taxon",
+                "publishing_app": "content-tagger",
+                "rendering_app": "collections",
+                "schema_name": "taxon",
+                "user_journey_document_supertype": "finding",
+                "links": {
+                  "parent_taxons": [
+                    {
+                      "base_path": "/childcare-parenting",
+                      "content_id": "206b7f3a-49b5-476f-af0f-fd27e2a68473",
+                      "title": "Parenting, childcare and children's services ",
+                      "description": "Health and welfare, financial help, finding a school, adoption, looked-after children, safeguarding.",
+                      "document_type": "taxon",
+                      "publishing_app": "content-tagger",
+                      "rendering_app": "collections",
+                      "schema_name": "taxon",
+                      "user_journey_document_supertype": "finding",
+                      "links": {}
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        }
+      ]
+    }
+  },
+  {
+    "base_path": "/childcare-parenting/refugee-runaway-and-homeless-children",
+    "content_id": "fbe2ce17-9ee6-4dcb-a523-ae5383d2cf4c",
+    "title": "Refugee, runaway and homeless children",
+    "description": "Guidance to stop children going missing, and to protect those who do.",
+    "document_type": "taxon",
+    "publishing_app": "content-tagger",
+    "rendering_app": "collections",
+    "schema_name": "taxon",
+    "user_journey_document_supertype": "finding",
+    "links": {
+      "child_taxons": [],
+      "parent_taxons": [
+        {
+          "base_path": "/education/safeguarding-child-protection",
+          "content_id": "5af6180c-d5db-4cc1-a68e-7bd066908132",
+          "title": "Safeguarding and child protection",
+          "description": "Prevent neglect and abuse, homeless children, data collection. ",
+          "document_type": "taxon",
+          "publishing_app": "content-tagger",
+          "rendering_app": "collections",
+          "schema_name": "taxon",
+          "user_journey_document_supertype": "finding",
+          "links": {
+            "parent_taxons": [
+              {
+                "base_path": "/childcare-parenting/safeguarding-and-social-care-for-children",
+                "content_id": "20eb4e84-98ee-404b-a4bd-fe8a36d5d71d",
+                "title": "Safeguarding and social care for children",
+                "description": "Child protection, children in care, become a social care provide. ",
+                "document_type": "taxon",
+                "publishing_app": "content-tagger",
+                "rendering_app": "collections",
+                "schema_name": "taxon",
+                "user_journey_document_supertype": "finding",
+                "links": {
+                  "parent_taxons": [
+                    {
+                      "base_path": "/childcare-parenting",
+                      "content_id": "206b7f3a-49b5-476f-af0f-fd27e2a68473",
+                      "title": "Parenting, childcare and children's services ",
+                      "description": "Health and welfare, financial help, finding a school, adoption, looked-after children, safeguarding.",
+                      "document_type": "taxon",
+                      "publishing_app": "content-tagger",
+                      "rendering_app": "collections",
+                      "schema_name": "taxon",
+                      "user_journey_document_supertype": "finding",
+                      "links": {}
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        }
+      ]
+    }
+  },
+  {
+    "base_path": "/childcare-parenting/serious-case-reviews",
+    "content_id": "e626b2fd-203e-4e2e-b8a5-121896ae22e7",
+    "title": "Serious case reviews",
+    "description": "Improving safeguarding after the serious injury or death of a child.",
+    "document_type": "taxon",
+    "publishing_app": "content-tagger",
+    "rendering_app": "collections",
+    "schema_name": "taxon",
+    "user_journey_document_supertype": "finding",
+    "links": {
+      "child_taxons": [],
+      "parent_taxons": [
+        {
+          "base_path": "/education/safeguarding-child-protection",
+          "content_id": "5af6180c-d5db-4cc1-a68e-7bd066908132",
+          "title": "Safeguarding and child protection",
+          "description": "Prevent neglect and abuse, homeless children, data collection. ",
+          "document_type": "taxon",
+          "publishing_app": "content-tagger",
+          "rendering_app": "collections",
+          "schema_name": "taxon",
+          "user_journey_document_supertype": "finding",
+          "links": {
+            "parent_taxons": [
+              {
+                "base_path": "/childcare-parenting/safeguarding-and-social-care-for-children",
+                "content_id": "20eb4e84-98ee-404b-a4bd-fe8a36d5d71d",
+                "title": "Safeguarding and social care for children",
+                "description": "Child protection, children in care, become a social care provide. ",
+                "document_type": "taxon",
+                "publishing_app": "content-tagger",
+                "rendering_app": "collections",
+                "schema_name": "taxon",
+                "user_journey_document_supertype": "finding",
+                "links": {
+                  "parent_taxons": [
+                    {
+                      "base_path": "/childcare-parenting",
+                      "content_id": "206b7f3a-49b5-476f-af0f-fd27e2a68473",
+                      "title": "Parenting, childcare and children's services ",
+                      "description": "Health and welfare, financial help, finding a school, adoption, looked-after children, safeguarding.",
+                      "document_type": "taxon",
+                      "publishing_app": "content-tagger",
+                      "rendering_app": "collections",
+                      "schema_name": "taxon",
+                      "user_journey_document_supertype": "finding",
+                      "links": {}
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        }
+      ]
+    }
+  },
+  {
+    "base_path": "/childcare-parenting/looked-after-children-children-in-care",
+    "content_id": "431a7fac-a2e8-4ffc-8fc7-bab10fc5e6d4",
+    "title": "Looked-after children and children in care",
+    "description": "Children's homes, data collection, children leaving care. ",
+    "document_type": "taxon",
+    "publishing_app": "content-tagger",
+    "rendering_app": "collections",
+    "schema_name": "taxon",
+    "user_journey_document_supertype": "finding",
+    "links": {
+      "child_taxons": [
+        {
+          "base_path": "/childcare-parenting/childrens-homes-and-other-accommodation",
+          "content_id": "50904cbc-3cde-4a3b-92ba-b75117671574",
+          "title": "Children's homes and other accommodation",
+          "description": "Securing a place. Regulations and quality standards, children's privacy and confidentiality.",
+          "document_type": "taxon",
+          "publishing_app": "content-tagger",
+          "rendering_app": "collections",
+          "schema_name": "taxon",
+          "user_journey_document_supertype": "finding",
+          "links": {
+            "child_taxons": []
+          }
+        },
+        {
+          "base_path": "/childcare-parenting/children-and-young-people-leaving-care",
+          "content_id": "d5c3d032-2c12-4bb3-8340-3cc5084ccba7",
+          "title": "Children and young people leaving care",
+          "description": "Care leavers' charter, council responsibilities. Staying put arrangements.",
+          "document_type": "taxon",
+          "publishing_app": "content-tagger",
+          "rendering_app": "collections",
+          "schema_name": "taxon",
+          "user_journey_document_supertype": "finding",
+          "links": {
+            "child_taxons": []
+          }
+        },
+        {
+          "base_path": "/childcare-parenting/data-collection-for-looked-after-children",
+          "content_id": "c359fa76-88ff-4298-817e-5cf974473853",
+          "title": "Data collection for looked-after children",
+          "description": "Submitting data. Validation rules, technical specification.",
+          "document_type": "taxon",
+          "publishing_app": "content-tagger",
+          "rendering_app": "collections",
+          "schema_name": "taxon",
+          "user_journey_document_supertype": "finding",
+          "links": {
+            "child_taxons": []
+          }
+        }
+      ],
+      "parent_taxons": [
+        {
+          "base_path": "/childcare-parenting/safeguarding-and-social-care-for-children",
+          "content_id": "20eb4e84-98ee-404b-a4bd-fe8a36d5d71d",
+          "title": "Safeguarding and social care for children",
+          "description": "Child protection, children in care, become a social care provide. ",
+          "document_type": "taxon",
+          "publishing_app": "content-tagger",
+          "rendering_app": "collections",
+          "schema_name": "taxon",
+          "user_journey_document_supertype": "finding",
+          "links": {
+            "parent_taxons": [
+              {
+                "base_path": "/childcare-parenting",
+                "content_id": "206b7f3a-49b5-476f-af0f-fd27e2a68473",
+                "title": "Parenting, childcare and children's services ",
+                "description": "Health and welfare, financial help, finding a school, adoption, looked-after children, safeguarding.",
+                "document_type": "taxon",
+                "publishing_app": "content-tagger",
+                "rendering_app": "collections",
+                "schema_name": "taxon",
+                "user_journey_document_supertype": "finding",
+                "links": {}
+              }
+            ]
+          }
+        }
+      ]
+    }
+  },
+  {
+    "base_path": "/childcare-parenting/childrens-homes-and-other-accommodation",
+    "content_id": "50904cbc-3cde-4a3b-92ba-b75117671574",
+    "title": "Children's homes and other accommodation",
+    "description": "Securing a place. Regulations and quality standards, children's privacy and confidentiality.",
+    "document_type": "taxon",
+    "publishing_app": "content-tagger",
+    "rendering_app": "collections",
+    "schema_name": "taxon",
+    "user_journey_document_supertype": "finding",
+    "links": {
+      "child_taxons": [],
+      "parent_taxons": [
+        {
+          "base_path": "/childcare-parenting/looked-after-children-children-in-care",
+          "content_id": "431a7fac-a2e8-4ffc-8fc7-bab10fc5e6d4",
+          "title": "Looked-after children and children in care",
+          "description": "Children's homes, data collection, children leaving care. ",
+          "document_type": "taxon",
+          "publishing_app": "content-tagger",
+          "rendering_app": "collections",
+          "schema_name": "taxon",
+          "user_journey_document_supertype": "finding",
+          "links": {
+            "parent_taxons": [
+              {
+                "base_path": "/childcare-parenting/safeguarding-and-social-care-for-children",
+                "content_id": "20eb4e84-98ee-404b-a4bd-fe8a36d5d71d",
+                "title": "Safeguarding and social care for children",
+                "description": "Child protection, children in care, become a social care provide. ",
+                "document_type": "taxon",
+                "publishing_app": "content-tagger",
+                "rendering_app": "collections",
+                "schema_name": "taxon",
+                "user_journey_document_supertype": "finding",
+                "links": {
+                  "parent_taxons": [
+                    {
+                      "base_path": "/childcare-parenting",
+                      "content_id": "206b7f3a-49b5-476f-af0f-fd27e2a68473",
+                      "title": "Parenting, childcare and children's services ",
+                      "description": "Health and welfare, financial help, finding a school, adoption, looked-after children, safeguarding.",
+                      "document_type": "taxon",
+                      "publishing_app": "content-tagger",
+                      "rendering_app": "collections",
+                      "schema_name": "taxon",
+                      "user_journey_document_supertype": "finding",
+                      "links": {}
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        }
+      ]
+    }
+  },
+  {
+    "base_path": "/childcare-parenting/children-and-young-people-leaving-care",
+    "content_id": "d5c3d032-2c12-4bb3-8340-3cc5084ccba7",
+    "title": "Children and young people leaving care",
+    "description": "Care leavers' charter, council responsibilities. Staying put arrangements.",
+    "document_type": "taxon",
+    "publishing_app": "content-tagger",
+    "rendering_app": "collections",
+    "schema_name": "taxon",
+    "user_journey_document_supertype": "finding",
+    "links": {
+      "child_taxons": [],
+      "parent_taxons": [
+        {
+          "base_path": "/childcare-parenting/looked-after-children-children-in-care",
+          "content_id": "431a7fac-a2e8-4ffc-8fc7-bab10fc5e6d4",
+          "title": "Looked-after children and children in care",
+          "description": "Children's homes, data collection, children leaving care. ",
+          "document_type": "taxon",
+          "publishing_app": "content-tagger",
+          "rendering_app": "collections",
+          "schema_name": "taxon",
+          "user_journey_document_supertype": "finding",
+          "links": {
+            "parent_taxons": [
+              {
+                "base_path": "/childcare-parenting/safeguarding-and-social-care-for-children",
+                "content_id": "20eb4e84-98ee-404b-a4bd-fe8a36d5d71d",
+                "title": "Safeguarding and social care for children",
+                "description": "Child protection, children in care, become a social care provide. ",
+                "document_type": "taxon",
+                "publishing_app": "content-tagger",
+                "rendering_app": "collections",
+                "schema_name": "taxon",
+                "user_journey_document_supertype": "finding",
+                "links": {
+                  "parent_taxons": [
+                    {
+                      "base_path": "/childcare-parenting",
+                      "content_id": "206b7f3a-49b5-476f-af0f-fd27e2a68473",
+                      "title": "Parenting, childcare and children's services ",
+                      "description": "Health and welfare, financial help, finding a school, adoption, looked-after children, safeguarding.",
+                      "document_type": "taxon",
+                      "publishing_app": "content-tagger",
+                      "rendering_app": "collections",
+                      "schema_name": "taxon",
+                      "user_journey_document_supertype": "finding",
+                      "links": {}
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        }
+      ]
+    }
+  },
+  {
+    "base_path": "/childcare-parenting/data-collection-for-looked-after-children",
+    "content_id": "c359fa76-88ff-4298-817e-5cf974473853",
+    "title": "Data collection for looked-after children",
+    "description": "Submitting data. Validation rules, technical specification.",
+    "document_type": "taxon",
+    "publishing_app": "content-tagger",
+    "rendering_app": "collections",
+    "schema_name": "taxon",
+    "user_journey_document_supertype": "finding",
+    "links": {
+      "child_taxons": [],
+      "parent_taxons": [
+        {
+          "base_path": "/childcare-parenting/looked-after-children-children-in-care",
+          "content_id": "431a7fac-a2e8-4ffc-8fc7-bab10fc5e6d4",
+          "title": "Looked-after children and children in care",
+          "description": "Children's homes, data collection, children leaving care. ",
+          "document_type": "taxon",
+          "publishing_app": "content-tagger",
+          "rendering_app": "collections",
+          "schema_name": "taxon",
+          "user_journey_document_supertype": "finding",
+          "links": {
+            "parent_taxons": [
+              {
+                "base_path": "/childcare-parenting/safeguarding-and-social-care-for-children",
+                "content_id": "20eb4e84-98ee-404b-a4bd-fe8a36d5d71d",
+                "title": "Safeguarding and social care for children",
+                "description": "Child protection, children in care, become a social care provide. ",
+                "document_type": "taxon",
+                "publishing_app": "content-tagger",
+                "rendering_app": "collections",
+                "schema_name": "taxon",
+                "user_journey_document_supertype": "finding",
+                "links": {
+                  "parent_taxons": [
+                    {
+                      "base_path": "/childcare-parenting",
+                      "content_id": "206b7f3a-49b5-476f-af0f-fd27e2a68473",
+                      "title": "Parenting, childcare and children's services ",
+                      "description": "Health and welfare, financial help, finding a school, adoption, looked-after children, safeguarding.",
+                      "document_type": "taxon",
+                      "publishing_app": "content-tagger",
+                      "rendering_app": "collections",
+                      "schema_name": "taxon",
+                      "user_journey_document_supertype": "finding",
+                      "links": {}
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        }
+      ]
+    }
+  },
+  {
+    "base_path": "/childcare-parenting/childrens-social-care-providers",
+    "content_id": "454b3d57-870e-4691-a700-abbf7d883c34",
+    "title": "Children's social care providers",
+    "description": "Registering, inspections, complaints, roles and responsibilities. Children's Act 1989 court orders.",
+    "document_type": "taxon",
+    "publishing_app": "content-tagger",
+    "rendering_app": "collections",
+    "schema_name": "taxon",
+    "user_journey_document_supertype": "finding",
+    "links": {
+      "child_taxons": [
+        {
+          "base_path": "/childcare-parenting/inspection-of-childrens-social-care-providers",
+          "content_id": "689bb0dd-bd50-42e0-9195-cfb020bc3ee7",
+          "title": "Inspection of children's social care providers",
+          "description": "Improvement notices, completing an evidence base, children's homes.",
+          "document_type": "taxon",
+          "publishing_app": "content-tagger",
+          "rendering_app": "collections",
+          "schema_name": "taxon",
+          "user_journey_document_supertype": "finding",
+          "links": {
+            "child_taxons": []
+          }
+        },
+        {
+          "base_path": "/childcare-parenting/becoming-a-childrens-social-care-provider",
+          "content_id": "45a65707-11c7-4e58-88b7-164f83d073e6",
+          "title": "Becoming a children's social care provider",
+          "description": "Application checklist, assessment questionnaire. How to register.",
+          "document_type": "taxon",
+          "publishing_app": "content-tagger",
+          "rendering_app": "collections",
+          "schema_name": "taxon",
+          "user_journey_document_supertype": "finding",
+          "links": {
+            "child_taxons": []
+          }
+        },
+        {
+          "base_path": "/childcare-parenting/social-care-provider-complaints",
+          "content_id": "49043bab-0075-414b-969b-b144539eef05",
+          "title": "Social care provider complaints",
+          "description": "Raise a complaint or concern about a social care provider.",
+          "document_type": "taxon",
+          "publishing_app": "content-tagger",
+          "rendering_app": "collections",
+          "schema_name": "taxon",
+          "user_journey_document_supertype": "finding",
+          "links": {
+            "child_taxons": []
+          }
+        }
+      ],
+      "parent_taxons": [
+        {
+          "base_path": "/childcare-parenting/safeguarding-and-social-care-for-children",
+          "content_id": "20eb4e84-98ee-404b-a4bd-fe8a36d5d71d",
+          "title": "Safeguarding and social care for children",
+          "description": "Child protection, children in care, become a social care provide. ",
+          "document_type": "taxon",
+          "publishing_app": "content-tagger",
+          "rendering_app": "collections",
+          "schema_name": "taxon",
+          "user_journey_document_supertype": "finding",
+          "links": {
+            "parent_taxons": [
+              {
+                "base_path": "/childcare-parenting",
+                "content_id": "206b7f3a-49b5-476f-af0f-fd27e2a68473",
+                "title": "Parenting, childcare and children's services ",
+                "description": "Health and welfare, financial help, finding a school, adoption, looked-after children, safeguarding.",
+                "document_type": "taxon",
+                "publishing_app": "content-tagger",
+                "rendering_app": "collections",
+                "schema_name": "taxon",
+                "user_journey_document_supertype": "finding",
+                "links": {}
+              }
+            ]
+          }
+        }
+      ]
+    }
+  },
+  {
+    "base_path": "/childcare-parenting/inspection-of-childrens-social-care-providers",
+    "content_id": "689bb0dd-bd50-42e0-9195-cfb020bc3ee7",
+    "title": "Inspection of children's social care providers",
+    "description": "Improvement notices, completing an evidence base, children's homes.",
+    "document_type": "taxon",
+    "publishing_app": "content-tagger",
+    "rendering_app": "collections",
+    "schema_name": "taxon",
+    "user_journey_document_supertype": "finding",
+    "links": {
+      "child_taxons": [],
+      "parent_taxons": [
+        {
+          "base_path": "/childcare-parenting/childrens-social-care-providers",
+          "content_id": "454b3d57-870e-4691-a700-abbf7d883c34",
+          "title": "Children's social care providers",
+          "description": "Registering, inspections, complaints, roles and responsibilities. Children's Act 1989 court orders.",
+          "document_type": "taxon",
+          "publishing_app": "content-tagger",
+          "rendering_app": "collections",
+          "schema_name": "taxon",
+          "user_journey_document_supertype": "finding",
+          "links": {
+            "parent_taxons": [
+              {
+                "base_path": "/childcare-parenting/safeguarding-and-social-care-for-children",
+                "content_id": "20eb4e84-98ee-404b-a4bd-fe8a36d5d71d",
+                "title": "Safeguarding and social care for children",
+                "description": "Child protection, children in care, become a social care provide. ",
+                "document_type": "taxon",
+                "publishing_app": "content-tagger",
+                "rendering_app": "collections",
+                "schema_name": "taxon",
+                "user_journey_document_supertype": "finding",
+                "links": {
+                  "parent_taxons": [
+                    {
+                      "base_path": "/childcare-parenting",
+                      "content_id": "206b7f3a-49b5-476f-af0f-fd27e2a68473",
+                      "title": "Parenting, childcare and children's services ",
+                      "description": "Health and welfare, financial help, finding a school, adoption, looked-after children, safeguarding.",
+                      "document_type": "taxon",
+                      "publishing_app": "content-tagger",
+                      "rendering_app": "collections",
+                      "schema_name": "taxon",
+                      "user_journey_document_supertype": "finding",
+                      "links": {}
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        }
+      ]
+    }
+  },
+  {
+    "base_path": "/childcare-parenting/becoming-a-childrens-social-care-provider",
+    "content_id": "45a65707-11c7-4e58-88b7-164f83d073e6",
+    "title": "Becoming a children's social care provider",
+    "description": "Application checklist, assessment questionnaire. How to register.",
+    "document_type": "taxon",
+    "publishing_app": "content-tagger",
+    "rendering_app": "collections",
+    "schema_name": "taxon",
+    "user_journey_document_supertype": "finding",
+    "links": {
+      "child_taxons": [],
+      "parent_taxons": [
+        {
+          "base_path": "/childcare-parenting/childrens-social-care-providers",
+          "content_id": "454b3d57-870e-4691-a700-abbf7d883c34",
+          "title": "Children's social care providers",
+          "description": "Registering, inspections, complaints, roles and responsibilities. Children's Act 1989 court orders.",
+          "document_type": "taxon",
+          "publishing_app": "content-tagger",
+          "rendering_app": "collections",
+          "schema_name": "taxon",
+          "user_journey_document_supertype": "finding",
+          "links": {
+            "parent_taxons": [
+              {
+                "base_path": "/childcare-parenting/safeguarding-and-social-care-for-children",
+                "content_id": "20eb4e84-98ee-404b-a4bd-fe8a36d5d71d",
+                "title": "Safeguarding and social care for children",
+                "description": "Child protection, children in care, become a social care provide. ",
+                "document_type": "taxon",
+                "publishing_app": "content-tagger",
+                "rendering_app": "collections",
+                "schema_name": "taxon",
+                "user_journey_document_supertype": "finding",
+                "links": {
+                  "parent_taxons": [
+                    {
+                      "base_path": "/childcare-parenting",
+                      "content_id": "206b7f3a-49b5-476f-af0f-fd27e2a68473",
+                      "title": "Parenting, childcare and children's services ",
+                      "description": "Health and welfare, financial help, finding a school, adoption, looked-after children, safeguarding.",
+                      "document_type": "taxon",
+                      "publishing_app": "content-tagger",
+                      "rendering_app": "collections",
+                      "schema_name": "taxon",
+                      "user_journey_document_supertype": "finding",
+                      "links": {}
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        }
+      ]
+    }
+  },
+  {
+    "base_path": "/childcare-parenting/social-care-provider-complaints",
+    "content_id": "49043bab-0075-414b-969b-b144539eef05",
+    "title": "Social care provider complaints",
+    "description": "Raise a complaint or concern about a social care provider.",
+    "document_type": "taxon",
+    "publishing_app": "content-tagger",
+    "rendering_app": "collections",
+    "schema_name": "taxon",
+    "user_journey_document_supertype": "finding",
+    "links": {
+      "child_taxons": [],
+      "parent_taxons": [
+        {
+          "base_path": "/childcare-parenting/childrens-social-care-providers",
+          "content_id": "454b3d57-870e-4691-a700-abbf7d883c34",
+          "title": "Children's social care providers",
+          "description": "Registering, inspections, complaints, roles and responsibilities. Children's Act 1989 court orders.",
+          "document_type": "taxon",
+          "publishing_app": "content-tagger",
+          "rendering_app": "collections",
+          "schema_name": "taxon",
+          "user_journey_document_supertype": "finding",
+          "links": {
+            "parent_taxons": [
+              {
+                "base_path": "/childcare-parenting/safeguarding-and-social-care-for-children",
+                "content_id": "20eb4e84-98ee-404b-a4bd-fe8a36d5d71d",
+                "title": "Safeguarding and social care for children",
+                "description": "Child protection, children in care, become a social care provide. ",
+                "document_type": "taxon",
+                "publishing_app": "content-tagger",
+                "rendering_app": "collections",
+                "schema_name": "taxon",
+                "user_journey_document_supertype": "finding",
+                "links": {
+                  "parent_taxons": [
+                    {
+                      "base_path": "/childcare-parenting",
+                      "content_id": "206b7f3a-49b5-476f-af0f-fd27e2a68473",
+                      "title": "Parenting, childcare and children's services ",
+                      "description": "Health and welfare, financial help, finding a school, adoption, looked-after children, safeguarding.",
+                      "document_type": "taxon",
+                      "publishing_app": "content-tagger",
+                      "rendering_app": "collections",
+                      "schema_name": "taxon",
+                      "user_journey_document_supertype": "finding",
+                      "links": {}
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        }
+      ]
+    }
+  },
+  {
+    "base_path": "/childcare-parenting/adoption-fostering-and-surrogacy",
+    "content_id": "5a9e6b26-ae64-4129-93ee-968028381e83",
+    "title": "Adoption, fostering and surrogacy",
+    "description": "Becoming a foster carer, adopting a child from the UK or abroad, looking after someone else's child.",
+    "document_type": "taxon",
+    "publishing_app": "content-tagger",
+    "rendering_app": "collections",
+    "schema_name": "taxon",
+    "user_journey_document_supertype": "finding",
+    "links": {
+      "child_taxons": [
+        {
+          "base_path": "/childcare-parenting/adoption",
+          "content_id": "13bba81c-b2b1-4b13-a3de-b24748977198",
+          "title": "Adoption",
+          "description": "Pay and leave, adopting through your council, inter-agency fees, placement, inspection forms.",
+          "document_type": "taxon",
+          "publishing_app": "content-tagger",
+          "rendering_app": "collections",
+          "schema_name": "taxon",
+          "user_journey_document_supertype": "finding",
+          "links": {
+            "child_taxons": []
+          }
+        },
+        {
+          "base_path": "/childcare-parenting/surrogacy",
+          "content_id": "b0c0b3c6-6ee2-4fce-9abd-4a73be10c483",
+          "title": "Surrogacy",
+          "description": "Surrogates rights, using a surrogate, parental leave and pay. ",
+          "document_type": "taxon",
+          "publishing_app": "content-tagger",
+          "rendering_app": "collections",
+          "schema_name": "taxon",
+          "user_journey_document_supertype": "finding",
+          "links": {
+            "child_taxons": []
+          }
+        },
+        {
+          "base_path": "/childcare-parenting/fostering",
+          "content_id": "f40a63ce-ac0c-4102-84d1-f1835cb7daac",
+          "title": "Fostering",
+          "description": "Training, standards, data collection forms, 'staying put' arrangements.",
+          "document_type": "taxon",
+          "publishing_app": "content-tagger",
+          "rendering_app": "collections",
+          "schema_name": "taxon",
+          "user_journey_document_supertype": "finding",
+          "links": {
+            "child_taxons": []
+          }
+        },
+        {
+          "base_path": "/childcare-parenting/special-guardianship",
+          "content_id": "29698d17-8ce4-46e6-b173-bde2b5977970",
+          "title": "Special guardianship",
+          "description": "Looking after someone else's child.",
+          "document_type": "taxon",
+          "publishing_app": "content-tagger",
+          "rendering_app": "collections",
+          "schema_name": "taxon",
+          "user_journey_document_supertype": "finding",
+          "links": {
+            "child_taxons": []
+          }
+        },
+        {
+          "base_path": "/childcare-parenting/intercountry-adoption",
+          "content_id": "b42ec0f9-d161-4be6-85c5-bf3933c1cca4",
+          "title": "Intercountry adoption",
+          "description": "Guidance for adoption agencies.",
+          "document_type": "taxon",
+          "publishing_app": "content-tagger",
+          "rendering_app": "collections",
+          "schema_name": "taxon",
+          "user_journey_document_supertype": "finding",
+          "links": {
+            "child_taxons": []
+          }
+        }
+      ],
+      "parent_taxons": [
+        {
+          "base_path": "/childcare-parenting",
+          "content_id": "206b7f3a-49b5-476f-af0f-fd27e2a68473",
+          "title": "Parenting, childcare and children's services ",
+          "description": "Health and welfare, financial help, finding a school, adoption, looked-after children, safeguarding.",
+          "document_type": "taxon",
+          "publishing_app": "content-tagger",
+          "rendering_app": "collections",
+          "schema_name": "taxon",
+          "user_journey_document_supertype": "finding",
+          "links": {}
+        }
+      ]
+    }
+  },
+  {
+    "base_path": "/childcare-parenting/adoption",
+    "content_id": "13bba81c-b2b1-4b13-a3de-b24748977198",
+    "title": "Adoption",
+    "description": "Pay and leave, adopting through your council, inter-agency fees, placement, inspection forms.",
+    "document_type": "taxon",
+    "publishing_app": "content-tagger",
+    "rendering_app": "collections",
+    "schema_name": "taxon",
+    "user_journey_document_supertype": "finding",
+    "links": {
+      "child_taxons": [],
+      "parent_taxons": [
+        {
+          "base_path": "/childcare-parenting/adoption-fostering-and-surrogacy",
+          "content_id": "5a9e6b26-ae64-4129-93ee-968028381e83",
+          "title": "Adoption, fostering and surrogacy",
+          "description": "Becoming a foster carer, adopting a child from the UK or abroad, looking after someone else's child.",
+          "document_type": "taxon",
+          "publishing_app": "content-tagger",
+          "rendering_app": "collections",
+          "schema_name": "taxon",
+          "user_journey_document_supertype": "finding",
+          "links": {
+            "parent_taxons": [
+              {
+                "base_path": "/childcare-parenting",
+                "content_id": "206b7f3a-49b5-476f-af0f-fd27e2a68473",
+                "title": "Parenting, childcare and children's services ",
+                "description": "Health and welfare, financial help, finding a school, adoption, looked-after children, safeguarding.",
+                "document_type": "taxon",
+                "publishing_app": "content-tagger",
+                "rendering_app": "collections",
+                "schema_name": "taxon",
+                "user_journey_document_supertype": "finding",
+                "links": {}
+              }
+            ]
+          }
+        }
+      ]
+    }
+  },
+  {
+    "base_path": "/childcare-parenting/surrogacy",
+    "content_id": "b0c0b3c6-6ee2-4fce-9abd-4a73be10c483",
+    "title": "Surrogacy",
+    "description": "Surrogates rights, using a surrogate, parental leave and pay. ",
+    "document_type": "taxon",
+    "publishing_app": "content-tagger",
+    "rendering_app": "collections",
+    "schema_name": "taxon",
+    "user_journey_document_supertype": "finding",
+    "links": {
+      "child_taxons": [],
+      "parent_taxons": [
+        {
+          "base_path": "/childcare-parenting/adoption-fostering-and-surrogacy",
+          "content_id": "5a9e6b26-ae64-4129-93ee-968028381e83",
+          "title": "Adoption, fostering and surrogacy",
+          "description": "Becoming a foster carer, adopting a child from the UK or abroad, looking after someone else's child.",
+          "document_type": "taxon",
+          "publishing_app": "content-tagger",
+          "rendering_app": "collections",
+          "schema_name": "taxon",
+          "user_journey_document_supertype": "finding",
+          "links": {
+            "parent_taxons": [
+              {
+                "base_path": "/childcare-parenting",
+                "content_id": "206b7f3a-49b5-476f-af0f-fd27e2a68473",
+                "title": "Parenting, childcare and children's services ",
+                "description": "Health and welfare, financial help, finding a school, adoption, looked-after children, safeguarding.",
+                "document_type": "taxon",
+                "publishing_app": "content-tagger",
+                "rendering_app": "collections",
+                "schema_name": "taxon",
+                "user_journey_document_supertype": "finding",
+                "links": {}
+              }
+            ]
+          }
+        }
+      ]
+    }
+  },
+  {
+    "base_path": "/childcare-parenting/fostering",
+    "content_id": "f40a63ce-ac0c-4102-84d1-f1835cb7daac",
+    "title": "Fostering",
+    "description": "Training, standards, data collection forms, 'staying put' arrangements.",
+    "document_type": "taxon",
+    "publishing_app": "content-tagger",
+    "rendering_app": "collections",
+    "schema_name": "taxon",
+    "user_journey_document_supertype": "finding",
+    "links": {
+      "child_taxons": [],
+      "parent_taxons": [
+        {
+          "base_path": "/childcare-parenting/adoption-fostering-and-surrogacy",
+          "content_id": "5a9e6b26-ae64-4129-93ee-968028381e83",
+          "title": "Adoption, fostering and surrogacy",
+          "description": "Becoming a foster carer, adopting a child from the UK or abroad, looking after someone else's child.",
+          "document_type": "taxon",
+          "publishing_app": "content-tagger",
+          "rendering_app": "collections",
+          "schema_name": "taxon",
+          "user_journey_document_supertype": "finding",
+          "links": {
+            "parent_taxons": [
+              {
+                "base_path": "/childcare-parenting",
+                "content_id": "206b7f3a-49b5-476f-af0f-fd27e2a68473",
+                "title": "Parenting, childcare and children's services ",
+                "description": "Health and welfare, financial help, finding a school, adoption, looked-after children, safeguarding.",
+                "document_type": "taxon",
+                "publishing_app": "content-tagger",
+                "rendering_app": "collections",
+                "schema_name": "taxon",
+                "user_journey_document_supertype": "finding",
+                "links": {}
+              }
+            ]
+          }
+        }
+      ]
+    }
+  },
+  {
+    "base_path": "/childcare-parenting/special-guardianship",
+    "content_id": "29698d17-8ce4-46e6-b173-bde2b5977970",
+    "title": "Special guardianship",
+    "description": "Looking after someone else's child.",
+    "document_type": "taxon",
+    "publishing_app": "content-tagger",
+    "rendering_app": "collections",
+    "schema_name": "taxon",
+    "user_journey_document_supertype": "finding",
+    "links": {
+      "child_taxons": [],
+      "parent_taxons": [
+        {
+          "base_path": "/childcare-parenting/adoption-fostering-and-surrogacy",
+          "content_id": "5a9e6b26-ae64-4129-93ee-968028381e83",
+          "title": "Adoption, fostering and surrogacy",
+          "description": "Becoming a foster carer, adopting a child from the UK or abroad, looking after someone else's child.",
+          "document_type": "taxon",
+          "publishing_app": "content-tagger",
+          "rendering_app": "collections",
+          "schema_name": "taxon",
+          "user_journey_document_supertype": "finding",
+          "links": {
+            "parent_taxons": [
+              {
+                "base_path": "/childcare-parenting",
+                "content_id": "206b7f3a-49b5-476f-af0f-fd27e2a68473",
+                "title": "Parenting, childcare and children's services ",
+                "description": "Health and welfare, financial help, finding a school, adoption, looked-after children, safeguarding.",
+                "document_type": "taxon",
+                "publishing_app": "content-tagger",
+                "rendering_app": "collections",
+                "schema_name": "taxon",
+                "user_journey_document_supertype": "finding",
+                "links": {}
+              }
+            ]
+          }
+        }
+      ]
+    }
+  },
+  {
+    "base_path": "/childcare-parenting/intercountry-adoption",
+    "content_id": "b42ec0f9-d161-4be6-85c5-bf3933c1cca4",
+    "title": "Intercountry adoption",
+    "description": "Guidance for adoption agencies.",
+    "document_type": "taxon",
+    "publishing_app": "content-tagger",
+    "rendering_app": "collections",
+    "schema_name": "taxon",
+    "user_journey_document_supertype": "finding",
+    "links": {
+      "child_taxons": [],
+      "parent_taxons": [
+        {
+          "base_path": "/childcare-parenting/adoption-fostering-and-surrogacy",
+          "content_id": "5a9e6b26-ae64-4129-93ee-968028381e83",
+          "title": "Adoption, fostering and surrogacy",
+          "description": "Becoming a foster carer, adopting a child from the UK or abroad, looking after someone else's child.",
+          "document_type": "taxon",
+          "publishing_app": "content-tagger",
+          "rendering_app": "collections",
+          "schema_name": "taxon",
+          "user_journey_document_supertype": "finding",
+          "links": {
+            "parent_taxons": [
+              {
+                "base_path": "/childcare-parenting",
+                "content_id": "206b7f3a-49b5-476f-af0f-fd27e2a68473",
+                "title": "Parenting, childcare and children's services ",
+                "description": "Health and welfare, financial help, finding a school, adoption, looked-after children, safeguarding.",
+                "document_type": "taxon",
+                "publishing_app": "content-tagger",
+                "rendering_app": "collections",
+                "schema_name": "taxon",
+                "user_journey_document_supertype": "finding",
+                "links": {}
+              }
+            ]
+          }
+        }
+      ]
+    }
+  },
+  {
+    "base_path": "/childcare-parenting/pregnancy-and-birth",
+    "content_id": "e4335adc-5dc3-47c0-bb27-4998792212eb",
+    "title": "Pregnancy and birth",
+    "description": "Parenting classes and family support, teenage pregnancy.",
+    "document_type": "taxon",
+    "publishing_app": "content-tagger",
+    "rendering_app": "collections",
+    "schema_name": "taxon",
+    "user_journey_document_supertype": "finding",
+    "links": {
+      "child_taxons": [
+        {
+          "base_path": "/childcare-parenting/working-time-off-when-having-a-baby",
+          "content_id": "1bd8be6f-fe5b-4b0b-a780-db1d873951b4",
+          "title": "Working and time off when you're having a baby",
+          "description": "Maternity allowance, paternal pay and leave, Shared Parental Leave (SPL).",
+          "document_type": "taxon",
+          "publishing_app": "content-tagger",
+          "rendering_app": "collections",
+          "schema_name": "taxon",
+          "user_journey_document_supertype": "finding",
+          "links": {
+            "child_taxons": []
+          }
+        },
+        {
+          "base_path": "/childcare-parenting/financial-support-costs-of-having-a-child",
+          "content_id": "6994997b-2e9e-48ab-80b5-dad4b7ec4839",
+          "title": "Financial support towards the costs of having a child",
+          "description": "Healthy Start, Sure Start Maternity Grant.",
+          "document_type": "taxon",
+          "publishing_app": "content-tagger",
+          "rendering_app": "collections",
+          "schema_name": "taxon",
+          "user_journey_document_supertype": "finding",
+          "links": {
+            "child_taxons": []
+          }
+        },
+        {
+          "base_path": "/childcare-parenting/register-the-birth-of-a-child",
+          "content_id": "8da62d85-47c0-42df-94c4-eaaeac329671",
+          "title": "Register the birth of a child",
+          "description": "Register a birth abroad or in the UK. Registering a stillbirth.",
+          "document_type": "taxon",
+          "publishing_app": "content-tagger",
+          "rendering_app": "collections",
+          "schema_name": "taxon",
+          "user_journey_document_supertype": "finding",
+          "links": {
+            "child_taxons": []
+          }
+        }
+      ],
+      "parent_taxons": [
+        {
+          "base_path": "/childcare-parenting",
+          "content_id": "206b7f3a-49b5-476f-af0f-fd27e2a68473",
+          "title": "Parenting, childcare and children's services ",
+          "description": "Health and welfare, financial help, finding a school, adoption, looked-after children, safeguarding.",
+          "document_type": "taxon",
+          "publishing_app": "content-tagger",
+          "rendering_app": "collections",
+          "schema_name": "taxon",
+          "user_journey_document_supertype": "finding",
+          "links": {}
+        }
+      ]
+    }
+  },
+  {
+    "base_path": "/childcare-parenting/working-time-off-when-having-a-baby",
+    "content_id": "1bd8be6f-fe5b-4b0b-a780-db1d873951b4",
+    "title": "Working and time off when you're having a baby",
+    "description": "Maternity allowance, paternal pay and leave, Shared Parental Leave (SPL).",
+    "document_type": "taxon",
+    "publishing_app": "content-tagger",
+    "rendering_app": "collections",
+    "schema_name": "taxon",
+    "user_journey_document_supertype": "finding",
+    "links": {
+      "child_taxons": [],
+      "parent_taxons": [
+        {
+          "base_path": "/childcare-parenting/pregnancy-and-birth",
+          "content_id": "e4335adc-5dc3-47c0-bb27-4998792212eb",
+          "title": "Pregnancy and birth",
+          "description": "Parenting classes and family support, teenage pregnancy.",
+          "document_type": "taxon",
+          "publishing_app": "content-tagger",
+          "rendering_app": "collections",
+          "schema_name": "taxon",
+          "user_journey_document_supertype": "finding",
+          "links": {
+            "parent_taxons": [
+              {
+                "base_path": "/childcare-parenting",
+                "content_id": "206b7f3a-49b5-476f-af0f-fd27e2a68473",
+                "title": "Parenting, childcare and children's services ",
+                "description": "Health and welfare, financial help, finding a school, adoption, looked-after children, safeguarding.",
+                "document_type": "taxon",
+                "publishing_app": "content-tagger",
+                "rendering_app": "collections",
+                "schema_name": "taxon",
+                "user_journey_document_supertype": "finding",
+                "links": {}
+              }
+            ]
+          }
+        }
+      ]
+    }
+  },
+  {
+    "base_path": "/childcare-parenting/financial-support-costs-of-having-a-child",
+    "content_id": "6994997b-2e9e-48ab-80b5-dad4b7ec4839",
+    "title": "Financial support towards the costs of having a child",
+    "description": "Healthy Start, Sure Start Maternity Grant.",
+    "document_type": "taxon",
+    "publishing_app": "content-tagger",
+    "rendering_app": "collections",
+    "schema_name": "taxon",
+    "user_journey_document_supertype": "finding",
+    "links": {
+      "child_taxons": [],
+      "parent_taxons": [
+        {
+          "base_path": "/childcare-parenting/pregnancy-and-birth",
+          "content_id": "e4335adc-5dc3-47c0-bb27-4998792212eb",
+          "title": "Pregnancy and birth",
+          "description": "Parenting classes and family support, teenage pregnancy.",
+          "document_type": "taxon",
+          "publishing_app": "content-tagger",
+          "rendering_app": "collections",
+          "schema_name": "taxon",
+          "user_journey_document_supertype": "finding",
+          "links": {
+            "parent_taxons": [
+              {
+                "base_path": "/childcare-parenting",
+                "content_id": "206b7f3a-49b5-476f-af0f-fd27e2a68473",
+                "title": "Parenting, childcare and children's services ",
+                "description": "Health and welfare, financial help, finding a school, adoption, looked-after children, safeguarding.",
+                "document_type": "taxon",
+                "publishing_app": "content-tagger",
+                "rendering_app": "collections",
+                "schema_name": "taxon",
+                "user_journey_document_supertype": "finding",
+                "links": {}
+              }
+            ]
+          }
+        }
+      ]
+    }
+  },
+  {
+    "base_path": "/childcare-parenting/register-the-birth-of-a-child",
+    "content_id": "8da62d85-47c0-42df-94c4-eaaeac329671",
+    "title": "Register the birth of a child",
+    "description": "Register a birth abroad or in the UK. Registering a stillbirth.",
+    "document_type": "taxon",
+    "publishing_app": "content-tagger",
+    "rendering_app": "collections",
+    "schema_name": "taxon",
+    "user_journey_document_supertype": "finding",
+    "links": {
+      "child_taxons": [],
+      "parent_taxons": [
+        {
+          "base_path": "/childcare-parenting/pregnancy-and-birth",
+          "content_id": "e4335adc-5dc3-47c0-bb27-4998792212eb",
+          "title": "Pregnancy and birth",
+          "description": "Parenting classes and family support, teenage pregnancy.",
+          "document_type": "taxon",
+          "publishing_app": "content-tagger",
+          "rendering_app": "collections",
+          "schema_name": "taxon",
+          "user_journey_document_supertype": "finding",
+          "links": {
+            "parent_taxons": [
+              {
+                "base_path": "/childcare-parenting",
+                "content_id": "206b7f3a-49b5-476f-af0f-fd27e2a68473",
+                "title": "Parenting, childcare and children's services ",
+                "description": "Health and welfare, financial help, finding a school, adoption, looked-after children, safeguarding.",
+                "document_type": "taxon",
+                "publishing_app": "content-tagger",
+                "rendering_app": "collections",
+                "schema_name": "taxon",
+                "user_journey_document_supertype": "finding",
+                "links": {}
+              }
+            ]
+          }
+        }
+      ]
+    }
+  },
+  {
+    "base_path": "/childcare-parenting/childrens-health-and-welfare",
+    "content_id": "2389dfd4-a0c4-4bd2-b7e6-06f465463d22",
+    "title": "Children's health and welfare",
+    "description": "Children's rights, child poverty, mental health, young carers.",
+    "document_type": "taxon",
+    "publishing_app": "content-tagger",
+    "rendering_app": "collections",
+    "schema_name": "taxon",
+    "user_journey_document_supertype": "finding",
+    "links": {
+      "child_taxons": [
+        {
+          "base_path": "/childcare-parenting/help-for-children-with-a-long-term-illness-or-disability",
+          "content_id": "fc2412f2-77d1-4559-96db-b467cda93990",
+          "title": "Help for children with a long-term illness or disability",
+          "description": "Children and families act, disabled children at school. ",
+          "document_type": "taxon",
+          "publishing_app": "content-tagger",
+          "rendering_app": "collections",
+          "schema_name": "taxon",
+          "user_journey_document_supertype": "finding",
+          "links": {
+            "child_taxons": []
+          }
+        },
+        {
+          "base_path": "/childcare-parenting/mental-health-of-children-and-young-people",
+          "content_id": "0edc28be-da72-4b33-8ecf-e83455eeaced",
+          "title": "Mental health of children and young people",
+          "description": "Behaviour in schools.",
+          "document_type": "taxon",
+          "publishing_app": "content-tagger",
+          "rendering_app": "collections",
+          "schema_name": "taxon",
+          "user_journey_document_supertype": "finding",
+          "links": {
+            "child_taxons": []
+          }
+        },
+        {
+          "base_path": "/childcare-parenting/young-carers",
+          "content_id": "d0ab64d5-b6c8-4f94-985b-7575cad8c26d",
+          "title": "Young carers",
+          "description": "Improving support, pathfinders programme.",
+          "document_type": "taxon",
+          "publishing_app": "content-tagger",
+          "rendering_app": "collections",
+          "schema_name": "taxon",
+          "user_journey_document_supertype": "finding",
+          "links": {
+            "child_taxons": []
+          }
+        },
+        {
+          "base_path": "/childcare-parenting/childrens-rights",
+          "content_id": "4f72853c-d9ea-4b34-a986-2f62359e9e40",
+          "title": "Children's rights",
+          "description": "Advocacy for children, leaving children at home.",
+          "document_type": "taxon",
+          "publishing_app": "content-tagger",
+          "rendering_app": "collections",
+          "schema_name": "taxon",
+          "user_journey_document_supertype": "finding",
+          "links": {
+            "child_taxons": []
+          }
+        },
+        {
+          "base_path": "/childcare-parenting/child-poverty",
+          "content_id": "eb6c325f-09b7-4873-86f0-6b2eacc4d27f",
+          "title": "Child poverty",
+          "description": "Advice and training for practitioners, basket of indicators.",
+          "document_type": "taxon",
+          "publishing_app": "content-tagger",
+          "rendering_app": "collections",
+          "schema_name": "taxon",
+          "user_journey_document_supertype": "finding",
+          "links": {
+            "child_taxons": []
+          }
+        },
+        {
+          "base_path": "/childcare-parenting/support-for-children-with-send",
+          "content_id": "44509d44-824f-40a2-babe-6388b6136b7b",
+          "title": "Support for children with special educational needs and disabilities (SEND)",
+          "description": "Assessments, guide for health professionals, reform funding for local authorities, surveys.",
+          "document_type": "taxon",
+          "publishing_app": "content-tagger",
+          "rendering_app": "collections",
+          "schema_name": "taxon",
+          "user_journey_document_supertype": "finding",
+          "links": {
+            "child_taxons": []
+          }
+        }
+      ],
+      "parent_taxons": [
+        {
+          "base_path": "/childcare-parenting",
+          "content_id": "206b7f3a-49b5-476f-af0f-fd27e2a68473",
+          "title": "Parenting, childcare and children's services ",
+          "description": "Health and welfare, financial help, finding a school, adoption, looked-after children, safeguarding.",
+          "document_type": "taxon",
+          "publishing_app": "content-tagger",
+          "rendering_app": "collections",
+          "schema_name": "taxon",
+          "user_journey_document_supertype": "finding",
+          "links": {}
+        }
+      ]
+    }
+  },
+  {
+    "base_path": "/childcare-parenting/help-for-children-with-a-long-term-illness-or-disability",
+    "content_id": "fc2412f2-77d1-4559-96db-b467cda93990",
+    "title": "Help for children with a long-term illness or disability",
+    "description": "Children and families act, disabled children at school. ",
+    "document_type": "taxon",
+    "publishing_app": "content-tagger",
+    "rendering_app": "collections",
+    "schema_name": "taxon",
+    "user_journey_document_supertype": "finding",
+    "links": {
+      "child_taxons": [],
+      "parent_taxons": [
+        {
+          "base_path": "/childcare-parenting/childrens-health-and-welfare",
+          "content_id": "2389dfd4-a0c4-4bd2-b7e6-06f465463d22",
+          "title": "Children's health and welfare",
+          "description": "Children's rights, child poverty, mental health, young carers.",
+          "document_type": "taxon",
+          "publishing_app": "content-tagger",
+          "rendering_app": "collections",
+          "schema_name": "taxon",
+          "user_journey_document_supertype": "finding",
+          "links": {
+            "parent_taxons": [
+              {
+                "base_path": "/childcare-parenting",
+                "content_id": "206b7f3a-49b5-476f-af0f-fd27e2a68473",
+                "title": "Parenting, childcare and children's services ",
+                "description": "Health and welfare, financial help, finding a school, adoption, looked-after children, safeguarding.",
+                "document_type": "taxon",
+                "publishing_app": "content-tagger",
+                "rendering_app": "collections",
+                "schema_name": "taxon",
+                "user_journey_document_supertype": "finding",
+                "links": {}
+              }
+            ]
+          }
+        }
+      ]
+    }
+  },
+  {
+    "base_path": "/childcare-parenting/mental-health-of-children-and-young-people",
+    "content_id": "0edc28be-da72-4b33-8ecf-e83455eeaced",
+    "title": "Mental health of children and young people",
+    "description": "Behaviour in schools.",
+    "document_type": "taxon",
+    "publishing_app": "content-tagger",
+    "rendering_app": "collections",
+    "schema_name": "taxon",
+    "user_journey_document_supertype": "finding",
+    "links": {
+      "child_taxons": [],
+      "parent_taxons": [
+        {
+          "base_path": "/childcare-parenting/childrens-health-and-welfare",
+          "content_id": "2389dfd4-a0c4-4bd2-b7e6-06f465463d22",
+          "title": "Children's health and welfare",
+          "description": "Children's rights, child poverty, mental health, young carers.",
+          "document_type": "taxon",
+          "publishing_app": "content-tagger",
+          "rendering_app": "collections",
+          "schema_name": "taxon",
+          "user_journey_document_supertype": "finding",
+          "links": {
+            "parent_taxons": [
+              {
+                "base_path": "/childcare-parenting",
+                "content_id": "206b7f3a-49b5-476f-af0f-fd27e2a68473",
+                "title": "Parenting, childcare and children's services ",
+                "description": "Health and welfare, financial help, finding a school, adoption, looked-after children, safeguarding.",
+                "document_type": "taxon",
+                "publishing_app": "content-tagger",
+                "rendering_app": "collections",
+                "schema_name": "taxon",
+                "user_journey_document_supertype": "finding",
+                "links": {}
+              }
+            ]
+          }
+        }
+      ]
+    }
+  },
+  {
+    "base_path": "/childcare-parenting/young-carers",
+    "content_id": "d0ab64d5-b6c8-4f94-985b-7575cad8c26d",
+    "title": "Young carers",
+    "description": "Improving support, pathfinders programme.",
+    "document_type": "taxon",
+    "publishing_app": "content-tagger",
+    "rendering_app": "collections",
+    "schema_name": "taxon",
+    "user_journey_document_supertype": "finding",
+    "links": {
+      "child_taxons": [],
+      "parent_taxons": [
+        {
+          "base_path": "/childcare-parenting/childrens-health-and-welfare",
+          "content_id": "2389dfd4-a0c4-4bd2-b7e6-06f465463d22",
+          "title": "Children's health and welfare",
+          "description": "Children's rights, child poverty, mental health, young carers.",
+          "document_type": "taxon",
+          "publishing_app": "content-tagger",
+          "rendering_app": "collections",
+          "schema_name": "taxon",
+          "user_journey_document_supertype": "finding",
+          "links": {
+            "parent_taxons": [
+              {
+                "base_path": "/childcare-parenting",
+                "content_id": "206b7f3a-49b5-476f-af0f-fd27e2a68473",
+                "title": "Parenting, childcare and children's services ",
+                "description": "Health and welfare, financial help, finding a school, adoption, looked-after children, safeguarding.",
+                "document_type": "taxon",
+                "publishing_app": "content-tagger",
+                "rendering_app": "collections",
+                "schema_name": "taxon",
+                "user_journey_document_supertype": "finding",
+                "links": {}
+              }
+            ]
+          }
+        }
+      ]
+    }
+  },
+  {
+    "base_path": "/childcare-parenting/childrens-rights",
+    "content_id": "4f72853c-d9ea-4b34-a986-2f62359e9e40",
+    "title": "Children's rights",
+    "description": "Advocacy for children, leaving children at home.",
+    "document_type": "taxon",
+    "publishing_app": "content-tagger",
+    "rendering_app": "collections",
+    "schema_name": "taxon",
+    "user_journey_document_supertype": "finding",
+    "links": {
+      "child_taxons": [],
+      "parent_taxons": [
+        {
+          "base_path": "/childcare-parenting/childrens-health-and-welfare",
+          "content_id": "2389dfd4-a0c4-4bd2-b7e6-06f465463d22",
+          "title": "Children's health and welfare",
+          "description": "Children's rights, child poverty, mental health, young carers.",
+          "document_type": "taxon",
+          "publishing_app": "content-tagger",
+          "rendering_app": "collections",
+          "schema_name": "taxon",
+          "user_journey_document_supertype": "finding",
+          "links": {
+            "parent_taxons": [
+              {
+                "base_path": "/childcare-parenting",
+                "content_id": "206b7f3a-49b5-476f-af0f-fd27e2a68473",
+                "title": "Parenting, childcare and children's services ",
+                "description": "Health and welfare, financial help, finding a school, adoption, looked-after children, safeguarding.",
+                "document_type": "taxon",
+                "publishing_app": "content-tagger",
+                "rendering_app": "collections",
+                "schema_name": "taxon",
+                "user_journey_document_supertype": "finding",
+                "links": {}
+              }
+            ]
+          }
+        }
+      ]
+    }
+  },
+  {
+    "base_path": "/childcare-parenting/child-poverty",
+    "content_id": "eb6c325f-09b7-4873-86f0-6b2eacc4d27f",
+    "title": "Child poverty",
+    "description": "Advice and training for practitioners, basket of indicators.",
+    "document_type": "taxon",
+    "publishing_app": "content-tagger",
+    "rendering_app": "collections",
+    "schema_name": "taxon",
+    "user_journey_document_supertype": "finding",
+    "links": {
+      "child_taxons": [],
+      "parent_taxons": [
+        {
+          "base_path": "/childcare-parenting/childrens-health-and-welfare",
+          "content_id": "2389dfd4-a0c4-4bd2-b7e6-06f465463d22",
+          "title": "Children's health and welfare",
+          "description": "Children's rights, child poverty, mental health, young carers.",
+          "document_type": "taxon",
+          "publishing_app": "content-tagger",
+          "rendering_app": "collections",
+          "schema_name": "taxon",
+          "user_journey_document_supertype": "finding",
+          "links": {
+            "parent_taxons": [
+              {
+                "base_path": "/childcare-parenting",
+                "content_id": "206b7f3a-49b5-476f-af0f-fd27e2a68473",
+                "title": "Parenting, childcare and children's services ",
+                "description": "Health and welfare, financial help, finding a school, adoption, looked-after children, safeguarding.",
+                "document_type": "taxon",
+                "publishing_app": "content-tagger",
+                "rendering_app": "collections",
+                "schema_name": "taxon",
+                "user_journey_document_supertype": "finding",
+                "links": {}
+              }
+            ]
+          }
+        }
+      ]
+    }
+  },
+  {
+    "base_path": "/childcare-parenting/support-for-children-with-send",
+    "content_id": "44509d44-824f-40a2-babe-6388b6136b7b",
+    "title": "Support for children with special educational needs and disabilities (SEND)",
+    "description": "Assessments, guide for health professionals, reform funding for local authorities, surveys.",
+    "document_type": "taxon",
+    "publishing_app": "content-tagger",
+    "rendering_app": "collections",
+    "schema_name": "taxon",
+    "user_journey_document_supertype": "finding",
+    "links": {
+      "child_taxons": [],
+      "parent_taxons": [
+        {
+          "base_path": "/childcare-parenting/childrens-health-and-welfare",
+          "content_id": "2389dfd4-a0c4-4bd2-b7e6-06f465463d22",
+          "title": "Children's health and welfare",
+          "description": "Children's rights, child poverty, mental health, young carers.",
+          "document_type": "taxon",
+          "publishing_app": "content-tagger",
+          "rendering_app": "collections",
+          "schema_name": "taxon",
+          "user_journey_document_supertype": "finding",
+          "links": {
+            "parent_taxons": [
+              {
+                "base_path": "/childcare-parenting",
+                "content_id": "206b7f3a-49b5-476f-af0f-fd27e2a68473",
+                "title": "Parenting, childcare and children's services ",
+                "description": "Health and welfare, financial help, finding a school, adoption, looked-after children, safeguarding.",
+                "document_type": "taxon",
+                "publishing_app": "content-tagger",
+                "rendering_app": "collections",
+                "schema_name": "taxon",
+                "user_journey_document_supertype": "finding",
+                "links": {}
+              }
+            ]
+          }
+        }
+      ]
+    }
+  },
+  {
+    "base_path": "/childcare-parenting/divorce-separation-and-legal-issues",
+    "content_id": "1423ec9f-d62c-40f7-b10e-a2bdf020d8b7",
+    "title": "Divorce, separation and legal issues",
+    "description": "Child maintenance, disagreements about parentage, child custody.",
+    "document_type": "taxon",
+    "publishing_app": "content-tagger",
+    "rendering_app": "collections",
+    "schema_name": "taxon",
+    "user_journey_document_supertype": "finding",
+    "links": {
+      "child_taxons": [
+        {
+          "base_path": "/childcare-parenting/disagreements-about-parentage",
+          "content_id": "237b2e72-c465-42fe-9293-8b6af21713c0",
+          "title": "Disagreements about parentage",
+          "description": "Child maintenance service, child support agency.",
+          "document_type": "taxon",
+          "publishing_app": "content-tagger",
+          "rendering_app": "collections",
+          "schema_name": "taxon",
+          "user_journey_document_supertype": "finding",
+          "links": {
+            "child_taxons": []
+          }
+        },
+        {
+          "base_path": "/childcare-parenting/child-custody",
+          "content_id": "9ed56732-8600-493e-8467-295233529718",
+          "title": "Child custody",
+          "description": "Arrange custody, abducted children, cross-border child protection.",
+          "document_type": "taxon",
+          "publishing_app": "content-tagger",
+          "rendering_app": "collections",
+          "schema_name": "taxon",
+          "user_journey_document_supertype": "finding",
+          "links": {
+            "child_taxons": []
+          }
+        },
+        {
+          "base_path": "/childcare-parenting/child-maintenance",
+          "content_id": "902af4ff-4a3b-4860-932a-f7d9a47c337e",
+          "title": "Child maintenance",
+          "description": "Arrange child maintenance, calculator.",
+          "document_type": "taxon",
+          "publishing_app": "content-tagger",
+          "rendering_app": "collections",
+          "schema_name": "taxon",
+          "user_journey_document_supertype": "finding",
+          "links": {
+            "child_taxons": []
+          }
+        }
+      ],
+      "parent_taxons": [
+        {
+          "base_path": "/childcare-parenting",
+          "content_id": "206b7f3a-49b5-476f-af0f-fd27e2a68473",
+          "title": "Parenting, childcare and children's services ",
+          "description": "Health and welfare, financial help, finding a school, adoption, looked-after children, safeguarding.",
+          "document_type": "taxon",
+          "publishing_app": "content-tagger",
+          "rendering_app": "collections",
+          "schema_name": "taxon",
+          "user_journey_document_supertype": "finding",
+          "links": {}
+        }
+      ]
+    }
+  },
+  {
+    "base_path": "/childcare-parenting/disagreements-about-parentage",
+    "content_id": "237b2e72-c465-42fe-9293-8b6af21713c0",
+    "title": "Disagreements about parentage",
+    "description": "Child maintenance service, child support agency.",
+    "document_type": "taxon",
+    "publishing_app": "content-tagger",
+    "rendering_app": "collections",
+    "schema_name": "taxon",
+    "user_journey_document_supertype": "finding",
+    "links": {
+      "child_taxons": [],
+      "parent_taxons": [
+        {
+          "base_path": "/childcare-parenting/divorce-separation-and-legal-issues",
+          "content_id": "1423ec9f-d62c-40f7-b10e-a2bdf020d8b7",
+          "title": "Divorce, separation and legal issues",
+          "description": "Child maintenance, disagreements about parentage, child custody.",
+          "document_type": "taxon",
+          "publishing_app": "content-tagger",
+          "rendering_app": "collections",
+          "schema_name": "taxon",
+          "user_journey_document_supertype": "finding",
+          "links": {
+            "parent_taxons": [
+              {
+                "base_path": "/childcare-parenting",
+                "content_id": "206b7f3a-49b5-476f-af0f-fd27e2a68473",
+                "title": "Parenting, childcare and children's services ",
+                "description": "Health and welfare, financial help, finding a school, adoption, looked-after children, safeguarding.",
+                "document_type": "taxon",
+                "publishing_app": "content-tagger",
+                "rendering_app": "collections",
+                "schema_name": "taxon",
+                "user_journey_document_supertype": "finding",
+                "links": {}
+              }
+            ]
+          }
+        }
+      ]
+    }
+  },
+  {
+    "base_path": "/childcare-parenting/child-custody",
+    "content_id": "9ed56732-8600-493e-8467-295233529718",
+    "title": "Child custody",
+    "description": "Arrange custody, abducted children, cross-border child protection.",
+    "document_type": "taxon",
+    "publishing_app": "content-tagger",
+    "rendering_app": "collections",
+    "schema_name": "taxon",
+    "user_journey_document_supertype": "finding",
+    "links": {
+      "child_taxons": [],
+      "parent_taxons": [
+        {
+          "base_path": "/childcare-parenting/divorce-separation-and-legal-issues",
+          "content_id": "1423ec9f-d62c-40f7-b10e-a2bdf020d8b7",
+          "title": "Divorce, separation and legal issues",
+          "description": "Child maintenance, disagreements about parentage, child custody.",
+          "document_type": "taxon",
+          "publishing_app": "content-tagger",
+          "rendering_app": "collections",
+          "schema_name": "taxon",
+          "user_journey_document_supertype": "finding",
+          "links": {
+            "parent_taxons": [
+              {
+                "base_path": "/childcare-parenting",
+                "content_id": "206b7f3a-49b5-476f-af0f-fd27e2a68473",
+                "title": "Parenting, childcare and children's services ",
+                "description": "Health and welfare, financial help, finding a school, adoption, looked-after children, safeguarding.",
+                "document_type": "taxon",
+                "publishing_app": "content-tagger",
+                "rendering_app": "collections",
+                "schema_name": "taxon",
+                "user_journey_document_supertype": "finding",
+                "links": {}
+              }
+            ]
+          }
+        }
+      ]
+    }
+  },
+  {
+    "base_path": "/childcare-parenting/child-maintenance",
+    "content_id": "902af4ff-4a3b-4860-932a-f7d9a47c337e",
+    "title": "Child maintenance",
+    "description": "Arrange child maintenance, calculator.",
+    "document_type": "taxon",
+    "publishing_app": "content-tagger",
+    "rendering_app": "collections",
+    "schema_name": "taxon",
+    "user_journey_document_supertype": "finding",
+    "links": {
+      "child_taxons": [],
+      "parent_taxons": [
+        {
+          "base_path": "/childcare-parenting/divorce-separation-and-legal-issues",
+          "content_id": "1423ec9f-d62c-40f7-b10e-a2bdf020d8b7",
+          "title": "Divorce, separation and legal issues",
+          "description": "Child maintenance, disagreements about parentage, child custody.",
+          "document_type": "taxon",
+          "publishing_app": "content-tagger",
+          "rendering_app": "collections",
+          "schema_name": "taxon",
+          "user_journey_document_supertype": "finding",
+          "links": {
+            "parent_taxons": [
+              {
+                "base_path": "/childcare-parenting",
+                "content_id": "206b7f3a-49b5-476f-af0f-fd27e2a68473",
+                "title": "Parenting, childcare and children's services ",
+                "description": "Health and welfare, financial help, finding a school, adoption, looked-after children, safeguarding.",
+                "document_type": "taxon",
+                "publishing_app": "content-tagger",
+                "rendering_app": "collections",
+                "schema_name": "taxon",
+                "user_journey_document_supertype": "finding",
+                "links": {}
+              }
+            ]
+          }
+        }
+      ]
+    }
+  },
+  {
+    "base_path": "/childcare-parenting/financial-help-if-you-have-children",
+    "content_id": "a44b1c68-807c-45fe-bc7b-a47586617863",
+    "title": "Financial help if you have children",
+    "description": "Child benefit, tax credits, financial support for childcare.",
+    "document_type": "taxon",
+    "publishing_app": "content-tagger",
+    "rendering_app": "collections",
+    "schema_name": "taxon",
+    "user_journey_document_supertype": "finding",
+    "links": {
+      "child_taxons": [
+        {
+          "base_path": "/childcare-parenting/financial-help-when-having-a-baby",
+          "content_id": "090f8b0b-02f6-446b-b2ec-6000d7cd8322",
+          "title": "Financial help when having a baby",
+          "description": "Sure start maternity grant, maternity and paternity allowance and leave, shared parental leave.",
+          "document_type": "taxon",
+          "publishing_app": "content-tagger",
+          "rendering_app": "collections",
+          "schema_name": "taxon",
+          "user_journey_document_supertype": "finding",
+          "links": {
+            "child_taxons": []
+          }
+        },
+        {
+          "base_path": "/childcare-parenting/tax-credits-if-you-have-children",
+          "content_id": "65a25d2c-a0e5-4283-921d-c928babfb6e4",
+          "title": "Tax credits if you have children",
+          "description": "Claim child tax credit, renew, overpayments, payment dates, working tax credit.",
+          "document_type": "taxon",
+          "publishing_app": "content-tagger",
+          "rendering_app": "collections",
+          "schema_name": "taxon",
+          "user_journey_document_supertype": "finding",
+          "links": {
+            "child_taxons": []
+          }
+        },
+        {
+          "base_path": "/childcare-parenting/child-benefit",
+          "content_id": "c73891d9-1ead-4075-8681-8189de727cb9",
+          "title": "Child benefit",
+          "description": "Claim child benefit, rates, tax calculator, guardians allowance. ",
+          "document_type": "taxon",
+          "publishing_app": "content-tagger",
+          "rendering_app": "collections",
+          "schema_name": "taxon",
+          "user_journey_document_supertype": "finding",
+          "links": {
+            "child_taxons": []
+          }
+        },
+        {
+          "base_path": "/childcare-parenting/savings-accounts-for-children",
+          "content_id": "7966b917-60ea-4276-981e-84c59dfc5f7a",
+          "title": "Savings accounts for children",
+          "description": "Individual savings accounts, interest, tax.",
+          "document_type": "taxon",
+          "publishing_app": "content-tagger",
+          "rendering_app": "collections",
+          "schema_name": "taxon",
+          "user_journey_document_supertype": "finding",
+          "links": {
+            "child_taxons": []
+          }
+        },
+        {
+          "base_path": "/childcare-parenting/financial-help-if-you-have-a-disabled-child",
+          "content_id": "7a2b6588-d734-4057-8d2f-f80a47123f17",
+          "title": "Financial help if you have a disabled child",
+          "description": "Childrens disability living allowance, facilities grants. ",
+          "document_type": "taxon",
+          "publishing_app": "content-tagger",
+          "rendering_app": "collections",
+          "schema_name": "taxon",
+          "user_journey_document_supertype": "finding",
+          "links": {
+            "child_taxons": []
+          }
+        },
+        {
+          "base_path": "/childcare-parenting/financial-help-if-youre-a-student-with-children",
+          "content_id": "9797d693-65f2-4e74-b652-2dae0ce7e4d4",
+          "title": "Financial help if you're a student with children",
+          "description": "Childcare grant, care to learn, learning allowance. ",
+          "document_type": "taxon",
+          "publishing_app": "content-tagger",
+          "rendering_app": "collections",
+          "schema_name": "taxon",
+          "user_journey_document_supertype": "finding",
+          "links": {
+            "child_taxons": []
+          }
+        },
+        {
+          "base_path": "/childcare-parenting/financial-support-for-childcare",
+          "content_id": "6391a4bc-6109-4da4-b311-f78954334969",
+          "title": "Financial support for childcare",
+          "description": "Childcare calculator, childcare grant, tax credits, help with costs. ",
+          "document_type": "taxon",
+          "publishing_app": "content-tagger",
+          "rendering_app": "collections",
+          "schema_name": "taxon",
+          "user_journey_document_supertype": "finding",
+          "links": {
+            "child_taxons": []
+          }
+        }
+      ],
+      "parent_taxons": [
+        {
+          "base_path": "/childcare-parenting",
+          "content_id": "206b7f3a-49b5-476f-af0f-fd27e2a68473",
+          "title": "Parenting, childcare and children's services ",
+          "description": "Health and welfare, financial help, finding a school, adoption, looked-after children, safeguarding.",
+          "document_type": "taxon",
+          "publishing_app": "content-tagger",
+          "rendering_app": "collections",
+          "schema_name": "taxon",
+          "user_journey_document_supertype": "finding",
+          "links": {}
+        }
+      ]
+    }
+  },
+  {
+    "base_path": "/childcare-parenting/financial-help-when-having-a-baby",
+    "content_id": "090f8b0b-02f6-446b-b2ec-6000d7cd8322",
+    "title": "Financial help when having a baby",
+    "description": "Sure start maternity grant, maternity and paternity allowance and leave, shared parental leave.",
+    "document_type": "taxon",
+    "publishing_app": "content-tagger",
+    "rendering_app": "collections",
+    "schema_name": "taxon",
+    "user_journey_document_supertype": "finding",
+    "links": {
+      "child_taxons": [],
+      "parent_taxons": [
+        {
+          "base_path": "/childcare-parenting/financial-help-if-you-have-children",
+          "content_id": "a44b1c68-807c-45fe-bc7b-a47586617863",
+          "title": "Financial help if you have children",
+          "description": "Child benefit, tax credits, financial support for childcare.",
+          "document_type": "taxon",
+          "publishing_app": "content-tagger",
+          "rendering_app": "collections",
+          "schema_name": "taxon",
+          "user_journey_document_supertype": "finding",
+          "links": {
+            "parent_taxons": [
+              {
+                "base_path": "/childcare-parenting",
+                "content_id": "206b7f3a-49b5-476f-af0f-fd27e2a68473",
+                "title": "Parenting, childcare and children's services ",
+                "description": "Health and welfare, financial help, finding a school, adoption, looked-after children, safeguarding.",
+                "document_type": "taxon",
+                "publishing_app": "content-tagger",
+                "rendering_app": "collections",
+                "schema_name": "taxon",
+                "user_journey_document_supertype": "finding",
+                "links": {}
+              }
+            ]
+          }
+        }
+      ]
+    }
+  },
+  {
+    "base_path": "/childcare-parenting/tax-credits-if-you-have-children",
+    "content_id": "65a25d2c-a0e5-4283-921d-c928babfb6e4",
+    "title": "Tax credits if you have children",
+    "description": "Claim child tax credit, renew, overpayments, payment dates, working tax credit.",
+    "document_type": "taxon",
+    "publishing_app": "content-tagger",
+    "rendering_app": "collections",
+    "schema_name": "taxon",
+    "user_journey_document_supertype": "finding",
+    "links": {
+      "child_taxons": [],
+      "parent_taxons": [
+        {
+          "base_path": "/childcare-parenting/financial-help-if-you-have-children",
+          "content_id": "a44b1c68-807c-45fe-bc7b-a47586617863",
+          "title": "Financial help if you have children",
+          "description": "Child benefit, tax credits, financial support for childcare.",
+          "document_type": "taxon",
+          "publishing_app": "content-tagger",
+          "rendering_app": "collections",
+          "schema_name": "taxon",
+          "user_journey_document_supertype": "finding",
+          "links": {
+            "parent_taxons": [
+              {
+                "base_path": "/childcare-parenting",
+                "content_id": "206b7f3a-49b5-476f-af0f-fd27e2a68473",
+                "title": "Parenting, childcare and children's services ",
+                "description": "Health and welfare, financial help, finding a school, adoption, looked-after children, safeguarding.",
+                "document_type": "taxon",
+                "publishing_app": "content-tagger",
+                "rendering_app": "collections",
+                "schema_name": "taxon",
+                "user_journey_document_supertype": "finding",
+                "links": {}
+              }
+            ]
+          }
+        }
+      ]
+    }
+  },
+  {
+    "base_path": "/childcare-parenting/child-benefit",
+    "content_id": "c73891d9-1ead-4075-8681-8189de727cb9",
+    "title": "Child benefit",
+    "description": "Claim child benefit, rates, tax calculator, guardians allowance. ",
+    "document_type": "taxon",
+    "publishing_app": "content-tagger",
+    "rendering_app": "collections",
+    "schema_name": "taxon",
+    "user_journey_document_supertype": "finding",
+    "links": {
+      "child_taxons": [],
+      "parent_taxons": [
+        {
+          "base_path": "/childcare-parenting/financial-help-if-you-have-children",
+          "content_id": "a44b1c68-807c-45fe-bc7b-a47586617863",
+          "title": "Financial help if you have children",
+          "description": "Child benefit, tax credits, financial support for childcare.",
+          "document_type": "taxon",
+          "publishing_app": "content-tagger",
+          "rendering_app": "collections",
+          "schema_name": "taxon",
+          "user_journey_document_supertype": "finding",
+          "links": {
+            "parent_taxons": [
+              {
+                "base_path": "/childcare-parenting",
+                "content_id": "206b7f3a-49b5-476f-af0f-fd27e2a68473",
+                "title": "Parenting, childcare and children's services ",
+                "description": "Health and welfare, financial help, finding a school, adoption, looked-after children, safeguarding.",
+                "document_type": "taxon",
+                "publishing_app": "content-tagger",
+                "rendering_app": "collections",
+                "schema_name": "taxon",
+                "user_journey_document_supertype": "finding",
+                "links": {}
+              }
+            ]
+          }
+        }
+      ]
+    }
+  },
+  {
+    "base_path": "/childcare-parenting/savings-accounts-for-children",
+    "content_id": "7966b917-60ea-4276-981e-84c59dfc5f7a",
+    "title": "Savings accounts for children",
+    "description": "Individual savings accounts, interest, tax.",
+    "document_type": "taxon",
+    "publishing_app": "content-tagger",
+    "rendering_app": "collections",
+    "schema_name": "taxon",
+    "user_journey_document_supertype": "finding",
+    "links": {
+      "child_taxons": [],
+      "parent_taxons": [
+        {
+          "base_path": "/childcare-parenting/financial-help-if-you-have-children",
+          "content_id": "a44b1c68-807c-45fe-bc7b-a47586617863",
+          "title": "Financial help if you have children",
+          "description": "Child benefit, tax credits, financial support for childcare.",
+          "document_type": "taxon",
+          "publishing_app": "content-tagger",
+          "rendering_app": "collections",
+          "schema_name": "taxon",
+          "user_journey_document_supertype": "finding",
+          "links": {
+            "parent_taxons": [
+              {
+                "base_path": "/childcare-parenting",
+                "content_id": "206b7f3a-49b5-476f-af0f-fd27e2a68473",
+                "title": "Parenting, childcare and children's services ",
+                "description": "Health and welfare, financial help, finding a school, adoption, looked-after children, safeguarding.",
+                "document_type": "taxon",
+                "publishing_app": "content-tagger",
+                "rendering_app": "collections",
+                "schema_name": "taxon",
+                "user_journey_document_supertype": "finding",
+                "links": {}
+              }
+            ]
+          }
+        }
+      ]
+    }
+  },
+  {
+    "base_path": "/childcare-parenting/financial-help-if-you-have-a-disabled-child",
+    "content_id": "7a2b6588-d734-4057-8d2f-f80a47123f17",
+    "title": "Financial help if you have a disabled child",
+    "description": "Childrens disability living allowance, facilities grants. ",
+    "document_type": "taxon",
+    "publishing_app": "content-tagger",
+    "rendering_app": "collections",
+    "schema_name": "taxon",
+    "user_journey_document_supertype": "finding",
+    "links": {
+      "child_taxons": [],
+      "parent_taxons": [
+        {
+          "base_path": "/childcare-parenting/financial-help-if-you-have-children",
+          "content_id": "a44b1c68-807c-45fe-bc7b-a47586617863",
+          "title": "Financial help if you have children",
+          "description": "Child benefit, tax credits, financial support for childcare.",
+          "document_type": "taxon",
+          "publishing_app": "content-tagger",
+          "rendering_app": "collections",
+          "schema_name": "taxon",
+          "user_journey_document_supertype": "finding",
+          "links": {
+            "parent_taxons": [
+              {
+                "base_path": "/childcare-parenting",
+                "content_id": "206b7f3a-49b5-476f-af0f-fd27e2a68473",
+                "title": "Parenting, childcare and children's services ",
+                "description": "Health and welfare, financial help, finding a school, adoption, looked-after children, safeguarding.",
+                "document_type": "taxon",
+                "publishing_app": "content-tagger",
+                "rendering_app": "collections",
+                "schema_name": "taxon",
+                "user_journey_document_supertype": "finding",
+                "links": {}
+              }
+            ]
+          }
+        }
+      ]
+    }
+  },
+  {
+    "base_path": "/childcare-parenting/financial-help-if-youre-a-student-with-children",
+    "content_id": "9797d693-65f2-4e74-b652-2dae0ce7e4d4",
+    "title": "Financial help if you're a student with children",
+    "description": "Childcare grant, care to learn, learning allowance. ",
+    "document_type": "taxon",
+    "publishing_app": "content-tagger",
+    "rendering_app": "collections",
+    "schema_name": "taxon",
+    "user_journey_document_supertype": "finding",
+    "links": {
+      "child_taxons": [],
+      "parent_taxons": [
+        {
+          "base_path": "/childcare-parenting/financial-help-if-you-have-children",
+          "content_id": "a44b1c68-807c-45fe-bc7b-a47586617863",
+          "title": "Financial help if you have children",
+          "description": "Child benefit, tax credits, financial support for childcare.",
+          "document_type": "taxon",
+          "publishing_app": "content-tagger",
+          "rendering_app": "collections",
+          "schema_name": "taxon",
+          "user_journey_document_supertype": "finding",
+          "links": {
+            "parent_taxons": [
+              {
+                "base_path": "/childcare-parenting",
+                "content_id": "206b7f3a-49b5-476f-af0f-fd27e2a68473",
+                "title": "Parenting, childcare and children's services ",
+                "description": "Health and welfare, financial help, finding a school, adoption, looked-after children, safeguarding.",
+                "document_type": "taxon",
+                "publishing_app": "content-tagger",
+                "rendering_app": "collections",
+                "schema_name": "taxon",
+                "user_journey_document_supertype": "finding",
+                "links": {}
+              }
+            ]
+          }
+        }
+      ]
+    }
+  },
+  {
+    "base_path": "/childcare-parenting/financial-support-for-childcare",
+    "content_id": "6391a4bc-6109-4da4-b311-f78954334969",
+    "title": "Financial support for childcare",
+    "description": "Childcare calculator, childcare grant, tax credits, help with costs. ",
+    "document_type": "taxon",
+    "publishing_app": "content-tagger",
+    "rendering_app": "collections",
+    "schema_name": "taxon",
+    "user_journey_document_supertype": "finding",
+    "links": {
+      "child_taxons": [],
+      "parent_taxons": [
+        {
+          "base_path": "/childcare-parenting/financial-help-if-you-have-children",
+          "content_id": "a44b1c68-807c-45fe-bc7b-a47586617863",
+          "title": "Financial help if you have children",
+          "description": "Child benefit, tax credits, financial support for childcare.",
+          "document_type": "taxon",
+          "publishing_app": "content-tagger",
+          "rendering_app": "collections",
+          "schema_name": "taxon",
+          "user_journey_document_supertype": "finding",
+          "links": {
+            "parent_taxons": [
+              {
+                "base_path": "/childcare-parenting",
+                "content_id": "206b7f3a-49b5-476f-af0f-fd27e2a68473",
+                "title": "Parenting, childcare and children's services ",
+                "description": "Health and welfare, financial help, finding a school, adoption, looked-after children, safeguarding.",
+                "document_type": "taxon",
+                "publishing_app": "content-tagger",
+                "rendering_app": "collections",
+                "schema_name": "taxon",
+                "user_journey_document_supertype": "finding",
+                "links": {}
+              }
+            ]
+          }
+        }
+      ]
+    }
+  },
+  {
+    "base_path": "/childcare-parenting/childcare-and-early-years",
+    "content_id": "f1d9c348-5c5e-4fc6-9172-13a62537d3ae",
+    "title": "Childcare and early years",
+    "description": "Finding childcare, running a childcare business, financial support.",
+    "document_type": "taxon",
+    "publishing_app": "content-tagger",
+    "rendering_app": "collections",
+    "schema_name": "taxon",
+    "user_journey_document_supertype": "finding",
+    "links": {
+      "child_taxons": [
+        {
+          "base_path": "/childcare-parenting/finding-childcare",
+          "content_id": "62562899-fed3-4876-ba61-80264d140009",
+          "title": "Finding childcare",
+          "description": "Arrange childcare and after-school care.",
+          "document_type": "taxon",
+          "publishing_app": "content-tagger",
+          "rendering_app": "collections",
+          "schema_name": "taxon",
+          "user_journey_document_supertype": "finding",
+          "links": {
+            "child_taxons": []
+          }
+        },
+        {
+          "base_path": "/childcare-parenting/data-collection-for-early-years-and-childcare",
+          "content_id": "4713d510-9dd1-479f-a2f3-9b2ec5cde0e3",
+          "title": "Data collection for early years and childcare",
+          "description": "Census, foundation stage profile return.",
+          "document_type": "taxon",
+          "publishing_app": "content-tagger",
+          "rendering_app": "collections",
+          "schema_name": "taxon",
+          "user_journey_document_supertype": "finding",
+          "links": {
+            "child_taxons": [
+              {
+                "base_path": "/childcare-parenting/early-years-census",
+                "content_id": "5a73303d-0c74-4115-9c3e-7d0e925cb1ae",
+                "title": "Early years census",
+                "description": "Guide, technical specification.",
+                "document_type": "taxon",
+                "publishing_app": "content-tagger",
+                "rendering_app": "collections",
+                "schema_name": "taxon",
+                "user_journey_document_supertype": "finding",
+                "links": {
+                  "child_taxons": []
+                }
+              },
+              {
+                "base_path": "/childcare-parenting/early-years-foundation-stage-profile-return",
+                "content_id": "84230b48-93db-45f9-a374-0a82bba90f4e",
+                "title": "Early years foundation stage profile return",
+                "description": "Return guide, technical specification.",
+                "document_type": "taxon",
+                "publishing_app": "content-tagger",
+                "rendering_app": "collections",
+                "schema_name": "taxon",
+                "user_journey_document_supertype": "finding",
+                "links": {
+                  "child_taxons": []
+                }
+              }
+            ]
+          }
+        },
+        {
+          "base_path": "/childcare-parenting/providing-childcare",
+          "content_id": "18cb575a-45a0-4ab8-8bff-12c48a2ee8d4",
+          "title": "Providing childcare",
+          "description": "Become a childcare provider, early years curriculum, early years funding. ",
+          "document_type": "taxon",
+          "publishing_app": "content-tagger",
+          "rendering_app": "collections",
+          "schema_name": "taxon",
+          "user_journey_document_supertype": "finding",
+          "links": {
+            "child_taxons": [
+              {
+                "base_path": "/childcare-parenting/childminding",
+                "content_id": "61842205-392f-43f8-a612-45310e8ab454",
+                "title": "Childminding",
+                "description": "Register as an early years childminder, childminder regulations, childcare inspections. ",
+                "document_type": "taxon",
+                "publishing_app": "content-tagger",
+                "rendering_app": "collections",
+                "schema_name": "taxon",
+                "user_journey_document_supertype": "finding",
+                "links": {
+                  "child_taxons": []
+                }
+              },
+              {
+                "base_path": "/childcare-parenting/recruiting-and-managing-early-years-staff",
+                "content_id": "6a1688d6-c0ed-4b2f-a5ea-aac3748c8394",
+                "title": "Recruiting and managing early years staff",
+                "description": "Initial teacher training, qualifications criteria.",
+                "document_type": "taxon",
+                "publishing_app": "content-tagger",
+                "rendering_app": "collections",
+                "schema_name": "taxon",
+                "user_journey_document_supertype": "finding",
+                "links": {
+                  "child_taxons": []
+                }
+              },
+              {
+                "base_path": "/childcare-parenting/pre-schools-and-nurseries",
+                "content_id": "9b32bfef-a79a-4253-99b5-a37b7d4d24f2",
+                "title": "Pre-schools and nurseries",
+                "description": "Childcare register inspections.",
+                "document_type": "taxon",
+                "publishing_app": "content-tagger",
+                "rendering_app": "collections",
+                "schema_name": "taxon",
+                "user_journey_document_supertype": "finding",
+                "links": {
+                  "child_taxons": []
+                }
+              },
+              {
+                "base_path": "/childcare-parenting/funding-and-finance-for-childcare-providers",
+                "content_id": "89b2ca59-0a37-4576-b226-95bde1e9efc4",
+                "title": "Funding and finance for childcare providers",
+                "description": "Pupil premium, early years pupil premium, early education enitlement. ",
+                "document_type": "taxon",
+                "publishing_app": "content-tagger",
+                "rendering_app": "collections",
+                "schema_name": "taxon",
+                "user_journey_document_supertype": "finding",
+                "links": {
+                  "child_taxons": []
+                }
+              },
+              {
+                "base_path": "/childcare-parenting/childrens-centres",
+                "content_id": "932cd756-d3ae-4f9d-a7bb-8b7178dc9adb",
+                "title": "Children's centres",
+                "description": "Inspections, Sure Start.",
+                "document_type": "taxon",
+                "publishing_app": "content-tagger",
+                "rendering_app": "collections",
+                "schema_name": "taxon",
+                "user_journey_document_supertype": "finding",
+                "links": {
+                  "child_taxons": []
+                }
+              },
+              {
+                "base_path": "/childcare-parenting/Early-years-curriculum-0-to-5",
+                "content_id": "b508d8eb-de70-4e08-b7d9-9e4a9f5bedae",
+                "title": "Early years curriculum (0 to 5)",
+                "description": "Early Years Foundation Stage.",
+                "document_type": "taxon",
+                "publishing_app": "content-tagger",
+                "rendering_app": "collections",
+                "schema_name": "taxon",
+                "user_journey_document_supertype": "finding",
+                "links": {
+                  "child_taxons": []
+                }
+              },
+              {
+                "base_path": "/childcare-parenting/becoming-a-childcare-provider",
+                "content_id": "39e60ce9-5b21-49e9-919f-2cf3ffa4b075",
+                "title": "Becoming a childcare provider",
+                "description": "Register with Ofsted, agencies, children's social care providers, financial references, DBS checks.",
+                "document_type": "taxon",
+                "publishing_app": "content-tagger",
+                "rendering_app": "collections",
+                "schema_name": "taxon",
+                "user_journey_document_supertype": "finding",
+                "links": {
+                  "child_taxons": []
+                }
+              },
+              {
+                "base_path": "/childcare-parenting/local-authority-early-years-funding-and-obligations",
+                "content_id": "1da1c700-cef8-45c4-9bb7-11a4b0003e10",
+                "title": "Local authority early years funding and obligations",
+                "description": "Entitlement guide, providing early education and childcare. ",
+                "document_type": "taxon",
+                "publishing_app": "content-tagger",
+                "rendering_app": "collections",
+                "schema_name": "taxon",
+                "user_journey_document_supertype": "finding",
+                "links": {
+                  "child_taxons": []
+                }
+              },
+              {
+                "base_path": "/childcare-parenting/performance-and-inspection-of-childcare-providers",
+                "content_id": "b52d05ab-bc36-4a68-9bbf-63417788af3c",
+                "title": "Performance and inspection of childcare providers",
+                "description": "Early years information, inspection guidance, Ofsted registration fee. ",
+                "document_type": "taxon",
+                "publishing_app": "content-tagger",
+                "rendering_app": "collections",
+                "schema_name": "taxon",
+                "user_journey_document_supertype": "finding",
+                "links": {
+                  "child_taxons": []
+                }
+              },
+              {
+                "base_path": "/childcare-parenting/qualifications-training-and-professional-development-for-childcare-providers",
+                "content_id": "f002c7d4-9d6c-4ad8-8174-28ec7d4510fe",
+                "title": "Qualifications, training and professional development for childcare providers",
+                "description": "Qualifications criteria.",
+                "document_type": "taxon",
+                "publishing_app": "content-tagger",
+                "rendering_app": "collections",
+                "schema_name": "taxon",
+                "user_journey_document_supertype": "finding",
+                "links": {
+                  "child_taxons": []
+                }
+              }
+            ]
+          }
+        }
+      ],
+      "parent_taxons": [
+        {
+          "base_path": "/childcare-parenting",
+          "content_id": "206b7f3a-49b5-476f-af0f-fd27e2a68473",
+          "title": "Parenting, childcare and children's services ",
+          "description": "Health and welfare, financial help, finding a school, adoption, looked-after children, safeguarding.",
+          "document_type": "taxon",
+          "publishing_app": "content-tagger",
+          "rendering_app": "collections",
+          "schema_name": "taxon",
+          "user_journey_document_supertype": "finding",
+          "links": {}
+        }
+      ]
+    }
+  },
+  {
+    "base_path": "/childcare-parenting/finding-childcare",
+    "content_id": "62562899-fed3-4876-ba61-80264d140009",
+    "title": "Finding childcare",
+    "description": "Arrange childcare and after-school care.",
+    "document_type": "taxon",
+    "publishing_app": "content-tagger",
+    "rendering_app": "collections",
+    "schema_name": "taxon",
+    "user_journey_document_supertype": "finding",
+    "links": {
+      "child_taxons": [],
+      "parent_taxons": [
+        {
+          "base_path": "/childcare-parenting/childcare-and-early-years",
+          "content_id": "f1d9c348-5c5e-4fc6-9172-13a62537d3ae",
+          "title": "Childcare and early years",
+          "description": "Finding childcare, running a childcare business, financial support.",
+          "document_type": "taxon",
+          "publishing_app": "content-tagger",
+          "rendering_app": "collections",
+          "schema_name": "taxon",
+          "user_journey_document_supertype": "finding",
+          "links": {
+            "parent_taxons": [
+              {
+                "base_path": "/childcare-parenting",
+                "content_id": "206b7f3a-49b5-476f-af0f-fd27e2a68473",
+                "title": "Parenting, childcare and children's services ",
+                "description": "Health and welfare, financial help, finding a school, adoption, looked-after children, safeguarding.",
+                "document_type": "taxon",
+                "publishing_app": "content-tagger",
+                "rendering_app": "collections",
+                "schema_name": "taxon",
+                "user_journey_document_supertype": "finding",
+                "links": {}
+              }
+            ]
+          }
+        }
+      ]
+    }
+  },
+  {
+    "base_path": "/childcare-parenting/data-collection-for-early-years-and-childcare",
+    "content_id": "4713d510-9dd1-479f-a2f3-9b2ec5cde0e3",
+    "title": "Data collection for early years and childcare",
+    "description": "Census, foundation stage profile return.",
+    "document_type": "taxon",
+    "publishing_app": "content-tagger",
+    "rendering_app": "collections",
+    "schema_name": "taxon",
+    "user_journey_document_supertype": "finding",
+    "links": {
+      "child_taxons": [
+        {
+          "base_path": "/childcare-parenting/early-years-census",
+          "content_id": "5a73303d-0c74-4115-9c3e-7d0e925cb1ae",
+          "title": "Early years census",
+          "description": "Guide, technical specification.",
+          "document_type": "taxon",
+          "publishing_app": "content-tagger",
+          "rendering_app": "collections",
+          "schema_name": "taxon",
+          "user_journey_document_supertype": "finding",
+          "links": {
+            "child_taxons": []
+          }
+        },
+        {
+          "base_path": "/childcare-parenting/early-years-foundation-stage-profile-return",
+          "content_id": "84230b48-93db-45f9-a374-0a82bba90f4e",
+          "title": "Early years foundation stage profile return",
+          "description": "Return guide, technical specification.",
+          "document_type": "taxon",
+          "publishing_app": "content-tagger",
+          "rendering_app": "collections",
+          "schema_name": "taxon",
+          "user_journey_document_supertype": "finding",
+          "links": {
+            "child_taxons": []
+          }
+        }
+      ],
+      "parent_taxons": [
+        {
+          "base_path": "/childcare-parenting/childcare-and-early-years",
+          "content_id": "f1d9c348-5c5e-4fc6-9172-13a62537d3ae",
+          "title": "Childcare and early years",
+          "description": "Finding childcare, running a childcare business, financial support.",
+          "document_type": "taxon",
+          "publishing_app": "content-tagger",
+          "rendering_app": "collections",
+          "schema_name": "taxon",
+          "user_journey_document_supertype": "finding",
+          "links": {
+            "parent_taxons": [
+              {
+                "base_path": "/childcare-parenting",
+                "content_id": "206b7f3a-49b5-476f-af0f-fd27e2a68473",
+                "title": "Parenting, childcare and children's services ",
+                "description": "Health and welfare, financial help, finding a school, adoption, looked-after children, safeguarding.",
+                "document_type": "taxon",
+                "publishing_app": "content-tagger",
+                "rendering_app": "collections",
+                "schema_name": "taxon",
+                "user_journey_document_supertype": "finding",
+                "links": {}
+              }
+            ]
+          }
+        }
+      ]
+    }
+  },
+  {
+    "base_path": "/childcare-parenting/early-years-census",
+    "content_id": "5a73303d-0c74-4115-9c3e-7d0e925cb1ae",
+    "title": "Early years census",
+    "description": "Guide, technical specification.",
+    "document_type": "taxon",
+    "publishing_app": "content-tagger",
+    "rendering_app": "collections",
+    "schema_name": "taxon",
+    "user_journey_document_supertype": "finding",
+    "links": {
+      "child_taxons": [],
+      "parent_taxons": [
+        {
+          "base_path": "/childcare-parenting/data-collection-for-early-years-and-childcare",
+          "content_id": "4713d510-9dd1-479f-a2f3-9b2ec5cde0e3",
+          "title": "Data collection for early years and childcare",
+          "description": "Census, foundation stage profile return.",
+          "document_type": "taxon",
+          "publishing_app": "content-tagger",
+          "rendering_app": "collections",
+          "schema_name": "taxon",
+          "user_journey_document_supertype": "finding",
+          "links": {
+            "parent_taxons": [
+              {
+                "base_path": "/childcare-parenting/childcare-and-early-years",
+                "content_id": "f1d9c348-5c5e-4fc6-9172-13a62537d3ae",
+                "title": "Childcare and early years",
+                "description": "Finding childcare, running a childcare business, financial support.",
+                "document_type": "taxon",
+                "publishing_app": "content-tagger",
+                "rendering_app": "collections",
+                "schema_name": "taxon",
+                "user_journey_document_supertype": "finding",
+                "links": {
+                  "parent_taxons": [
+                    {
+                      "base_path": "/childcare-parenting",
+                      "content_id": "206b7f3a-49b5-476f-af0f-fd27e2a68473",
+                      "title": "Parenting, childcare and children's services ",
+                      "description": "Health and welfare, financial help, finding a school, adoption, looked-after children, safeguarding.",
+                      "document_type": "taxon",
+                      "publishing_app": "content-tagger",
+                      "rendering_app": "collections",
+                      "schema_name": "taxon",
+                      "user_journey_document_supertype": "finding",
+                      "links": {}
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        }
+      ]
+    }
+  },
+  {
+    "base_path": "/childcare-parenting/early-years-foundation-stage-profile-return",
+    "content_id": "84230b48-93db-45f9-a374-0a82bba90f4e",
+    "title": "Early years foundation stage profile return",
+    "description": "Return guide, technical specification.",
+    "document_type": "taxon",
+    "publishing_app": "content-tagger",
+    "rendering_app": "collections",
+    "schema_name": "taxon",
+    "user_journey_document_supertype": "finding",
+    "links": {
+      "child_taxons": [],
+      "parent_taxons": [
+        {
+          "base_path": "/childcare-parenting/data-collection-for-early-years-and-childcare",
+          "content_id": "4713d510-9dd1-479f-a2f3-9b2ec5cde0e3",
+          "title": "Data collection for early years and childcare",
+          "description": "Census, foundation stage profile return.",
+          "document_type": "taxon",
+          "publishing_app": "content-tagger",
+          "rendering_app": "collections",
+          "schema_name": "taxon",
+          "user_journey_document_supertype": "finding",
+          "links": {
+            "parent_taxons": [
+              {
+                "base_path": "/childcare-parenting/childcare-and-early-years",
+                "content_id": "f1d9c348-5c5e-4fc6-9172-13a62537d3ae",
+                "title": "Childcare and early years",
+                "description": "Finding childcare, running a childcare business, financial support.",
+                "document_type": "taxon",
+                "publishing_app": "content-tagger",
+                "rendering_app": "collections",
+                "schema_name": "taxon",
+                "user_journey_document_supertype": "finding",
+                "links": {
+                  "parent_taxons": [
+                    {
+                      "base_path": "/childcare-parenting",
+                      "content_id": "206b7f3a-49b5-476f-af0f-fd27e2a68473",
+                      "title": "Parenting, childcare and children's services ",
+                      "description": "Health and welfare, financial help, finding a school, adoption, looked-after children, safeguarding.",
+                      "document_type": "taxon",
+                      "publishing_app": "content-tagger",
+                      "rendering_app": "collections",
+                      "schema_name": "taxon",
+                      "user_journey_document_supertype": "finding",
+                      "links": {}
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        }
+      ]
+    }
+  },
+  {
+    "base_path": "/childcare-parenting/providing-childcare",
+    "content_id": "18cb575a-45a0-4ab8-8bff-12c48a2ee8d4",
+    "title": "Providing childcare",
+    "description": "Become a childcare provider, early years curriculum, early years funding. ",
+    "document_type": "taxon",
+    "publishing_app": "content-tagger",
+    "rendering_app": "collections",
+    "schema_name": "taxon",
+    "user_journey_document_supertype": "finding",
+    "links": {
+      "child_taxons": [
+        {
+          "base_path": "/childcare-parenting/childminding",
+          "content_id": "61842205-392f-43f8-a612-45310e8ab454",
+          "title": "Childminding",
+          "description": "Register as an early years childminder, childminder regulations, childcare inspections. ",
+          "document_type": "taxon",
+          "publishing_app": "content-tagger",
+          "rendering_app": "collections",
+          "schema_name": "taxon",
+          "user_journey_document_supertype": "finding",
+          "links": {
+            "child_taxons": []
+          }
+        },
+        {
+          "base_path": "/childcare-parenting/recruiting-and-managing-early-years-staff",
+          "content_id": "6a1688d6-c0ed-4b2f-a5ea-aac3748c8394",
+          "title": "Recruiting and managing early years staff",
+          "description": "Initial teacher training, qualifications criteria.",
+          "document_type": "taxon",
+          "publishing_app": "content-tagger",
+          "rendering_app": "collections",
+          "schema_name": "taxon",
+          "user_journey_document_supertype": "finding",
+          "links": {
+            "child_taxons": []
+          }
+        },
+        {
+          "base_path": "/childcare-parenting/pre-schools-and-nurseries",
+          "content_id": "9b32bfef-a79a-4253-99b5-a37b7d4d24f2",
+          "title": "Pre-schools and nurseries",
+          "description": "Childcare register inspections.",
+          "document_type": "taxon",
+          "publishing_app": "content-tagger",
+          "rendering_app": "collections",
+          "schema_name": "taxon",
+          "user_journey_document_supertype": "finding",
+          "links": {
+            "child_taxons": []
+          }
+        },
+        {
+          "base_path": "/childcare-parenting/funding-and-finance-for-childcare-providers",
+          "content_id": "89b2ca59-0a37-4576-b226-95bde1e9efc4",
+          "title": "Funding and finance for childcare providers",
+          "description": "Pupil premium, early years pupil premium, early education enitlement. ",
+          "document_type": "taxon",
+          "publishing_app": "content-tagger",
+          "rendering_app": "collections",
+          "schema_name": "taxon",
+          "user_journey_document_supertype": "finding",
+          "links": {
+            "child_taxons": []
+          }
+        },
+        {
+          "base_path": "/childcare-parenting/childrens-centres",
+          "content_id": "932cd756-d3ae-4f9d-a7bb-8b7178dc9adb",
+          "title": "Children's centres",
+          "description": "Inspections, Sure Start.",
+          "document_type": "taxon",
+          "publishing_app": "content-tagger",
+          "rendering_app": "collections",
+          "schema_name": "taxon",
+          "user_journey_document_supertype": "finding",
+          "links": {
+            "child_taxons": []
+          }
+        },
+        {
+          "base_path": "/childcare-parenting/Early-years-curriculum-0-to-5",
+          "content_id": "b508d8eb-de70-4e08-b7d9-9e4a9f5bedae",
+          "title": "Early years curriculum (0 to 5)",
+          "description": "Early Years Foundation Stage.",
+          "document_type": "taxon",
+          "publishing_app": "content-tagger",
+          "rendering_app": "collections",
+          "schema_name": "taxon",
+          "user_journey_document_supertype": "finding",
+          "links": {
+            "child_taxons": []
+          }
+        },
+        {
+          "base_path": "/childcare-parenting/becoming-a-childcare-provider",
+          "content_id": "39e60ce9-5b21-49e9-919f-2cf3ffa4b075",
+          "title": "Becoming a childcare provider",
+          "description": "Register with Ofsted, agencies, children's social care providers, financial references, DBS checks.",
+          "document_type": "taxon",
+          "publishing_app": "content-tagger",
+          "rendering_app": "collections",
+          "schema_name": "taxon",
+          "user_journey_document_supertype": "finding",
+          "links": {
+            "child_taxons": []
+          }
+        },
+        {
+          "base_path": "/childcare-parenting/local-authority-early-years-funding-and-obligations",
+          "content_id": "1da1c700-cef8-45c4-9bb7-11a4b0003e10",
+          "title": "Local authority early years funding and obligations",
+          "description": "Entitlement guide, providing early education and childcare. ",
+          "document_type": "taxon",
+          "publishing_app": "content-tagger",
+          "rendering_app": "collections",
+          "schema_name": "taxon",
+          "user_journey_document_supertype": "finding",
+          "links": {
+            "child_taxons": []
+          }
+        },
+        {
+          "base_path": "/childcare-parenting/performance-and-inspection-of-childcare-providers",
+          "content_id": "b52d05ab-bc36-4a68-9bbf-63417788af3c",
+          "title": "Performance and inspection of childcare providers",
+          "description": "Early years information, inspection guidance, Ofsted registration fee. ",
+          "document_type": "taxon",
+          "publishing_app": "content-tagger",
+          "rendering_app": "collections",
+          "schema_name": "taxon",
+          "user_journey_document_supertype": "finding",
+          "links": {
+            "child_taxons": []
+          }
+        },
+        {
+          "base_path": "/childcare-parenting/qualifications-training-and-professional-development-for-childcare-providers",
+          "content_id": "f002c7d4-9d6c-4ad8-8174-28ec7d4510fe",
+          "title": "Qualifications, training and professional development for childcare providers",
+          "description": "Qualifications criteria.",
+          "document_type": "taxon",
+          "publishing_app": "content-tagger",
+          "rendering_app": "collections",
+          "schema_name": "taxon",
+          "user_journey_document_supertype": "finding",
+          "links": {
+            "child_taxons": []
+          }
+        }
+      ],
+      "parent_taxons": [
+        {
+          "base_path": "/childcare-parenting/childcare-and-early-years",
+          "content_id": "f1d9c348-5c5e-4fc6-9172-13a62537d3ae",
+          "title": "Childcare and early years",
+          "description": "Finding childcare, running a childcare business, financial support.",
+          "document_type": "taxon",
+          "publishing_app": "content-tagger",
+          "rendering_app": "collections",
+          "schema_name": "taxon",
+          "user_journey_document_supertype": "finding",
+          "links": {
+            "parent_taxons": [
+              {
+                "base_path": "/childcare-parenting",
+                "content_id": "206b7f3a-49b5-476f-af0f-fd27e2a68473",
+                "title": "Parenting, childcare and children's services ",
+                "description": "Health and welfare, financial help, finding a school, adoption, looked-after children, safeguarding.",
+                "document_type": "taxon",
+                "publishing_app": "content-tagger",
+                "rendering_app": "collections",
+                "schema_name": "taxon",
+                "user_journey_document_supertype": "finding",
+                "links": {}
+              }
+            ]
+          }
+        }
+      ]
+    }
+  },
+  {
+    "base_path": "/childcare-parenting/childminding",
+    "content_id": "61842205-392f-43f8-a612-45310e8ab454",
+    "title": "Childminding",
+    "description": "Register as an early years childminder, childminder regulations, childcare inspections. ",
+    "document_type": "taxon",
+    "publishing_app": "content-tagger",
+    "rendering_app": "collections",
+    "schema_name": "taxon",
+    "user_journey_document_supertype": "finding",
+    "links": {
+      "child_taxons": [],
+      "parent_taxons": [
+        {
+          "base_path": "/childcare-parenting/providing-childcare",
+          "content_id": "18cb575a-45a0-4ab8-8bff-12c48a2ee8d4",
+          "title": "Providing childcare",
+          "description": "Become a childcare provider, early years curriculum, early years funding. ",
+          "document_type": "taxon",
+          "publishing_app": "content-tagger",
+          "rendering_app": "collections",
+          "schema_name": "taxon",
+          "user_journey_document_supertype": "finding",
+          "links": {
+            "parent_taxons": [
+              {
+                "base_path": "/childcare-parenting/childcare-and-early-years",
+                "content_id": "f1d9c348-5c5e-4fc6-9172-13a62537d3ae",
+                "title": "Childcare and early years",
+                "description": "Finding childcare, running a childcare business, financial support.",
+                "document_type": "taxon",
+                "publishing_app": "content-tagger",
+                "rendering_app": "collections",
+                "schema_name": "taxon",
+                "user_journey_document_supertype": "finding",
+                "links": {
+                  "parent_taxons": [
+                    {
+                      "base_path": "/childcare-parenting",
+                      "content_id": "206b7f3a-49b5-476f-af0f-fd27e2a68473",
+                      "title": "Parenting, childcare and children's services ",
+                      "description": "Health and welfare, financial help, finding a school, adoption, looked-after children, safeguarding.",
+                      "document_type": "taxon",
+                      "publishing_app": "content-tagger",
+                      "rendering_app": "collections",
+                      "schema_name": "taxon",
+                      "user_journey_document_supertype": "finding",
+                      "links": {}
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        }
+      ]
+    }
+  },
+  {
+    "base_path": "/childcare-parenting/recruiting-and-managing-early-years-staff",
+    "content_id": "6a1688d6-c0ed-4b2f-a5ea-aac3748c8394",
+    "title": "Recruiting and managing early years staff",
+    "description": "Initial teacher training, qualifications criteria.",
+    "document_type": "taxon",
+    "publishing_app": "content-tagger",
+    "rendering_app": "collections",
+    "schema_name": "taxon",
+    "user_journey_document_supertype": "finding",
+    "links": {
+      "child_taxons": [],
+      "parent_taxons": [
+        {
+          "base_path": "/childcare-parenting/providing-childcare",
+          "content_id": "18cb575a-45a0-4ab8-8bff-12c48a2ee8d4",
+          "title": "Providing childcare",
+          "description": "Become a childcare provider, early years curriculum, early years funding. ",
+          "document_type": "taxon",
+          "publishing_app": "content-tagger",
+          "rendering_app": "collections",
+          "schema_name": "taxon",
+          "user_journey_document_supertype": "finding",
+          "links": {
+            "parent_taxons": [
+              {
+                "base_path": "/childcare-parenting/childcare-and-early-years",
+                "content_id": "f1d9c348-5c5e-4fc6-9172-13a62537d3ae",
+                "title": "Childcare and early years",
+                "description": "Finding childcare, running a childcare business, financial support.",
+                "document_type": "taxon",
+                "publishing_app": "content-tagger",
+                "rendering_app": "collections",
+                "schema_name": "taxon",
+                "user_journey_document_supertype": "finding",
+                "links": {
+                  "parent_taxons": [
+                    {
+                      "base_path": "/childcare-parenting",
+                      "content_id": "206b7f3a-49b5-476f-af0f-fd27e2a68473",
+                      "title": "Parenting, childcare and children's services ",
+                      "description": "Health and welfare, financial help, finding a school, adoption, looked-after children, safeguarding.",
+                      "document_type": "taxon",
+                      "publishing_app": "content-tagger",
+                      "rendering_app": "collections",
+                      "schema_name": "taxon",
+                      "user_journey_document_supertype": "finding",
+                      "links": {}
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        }
+      ]
+    }
+  },
+  {
+    "base_path": "/childcare-parenting/pre-schools-and-nurseries",
+    "content_id": "9b32bfef-a79a-4253-99b5-a37b7d4d24f2",
+    "title": "Pre-schools and nurseries",
+    "description": "Childcare register inspections.",
+    "document_type": "taxon",
+    "publishing_app": "content-tagger",
+    "rendering_app": "collections",
+    "schema_name": "taxon",
+    "user_journey_document_supertype": "finding",
+    "links": {
+      "child_taxons": [],
+      "parent_taxons": [
+        {
+          "base_path": "/childcare-parenting/providing-childcare",
+          "content_id": "18cb575a-45a0-4ab8-8bff-12c48a2ee8d4",
+          "title": "Providing childcare",
+          "description": "Become a childcare provider, early years curriculum, early years funding. ",
+          "document_type": "taxon",
+          "publishing_app": "content-tagger",
+          "rendering_app": "collections",
+          "schema_name": "taxon",
+          "user_journey_document_supertype": "finding",
+          "links": {
+            "parent_taxons": [
+              {
+                "base_path": "/childcare-parenting/childcare-and-early-years",
+                "content_id": "f1d9c348-5c5e-4fc6-9172-13a62537d3ae",
+                "title": "Childcare and early years",
+                "description": "Finding childcare, running a childcare business, financial support.",
+                "document_type": "taxon",
+                "publishing_app": "content-tagger",
+                "rendering_app": "collections",
+                "schema_name": "taxon",
+                "user_journey_document_supertype": "finding",
+                "links": {
+                  "parent_taxons": [
+                    {
+                      "base_path": "/childcare-parenting",
+                      "content_id": "206b7f3a-49b5-476f-af0f-fd27e2a68473",
+                      "title": "Parenting, childcare and children's services ",
+                      "description": "Health and welfare, financial help, finding a school, adoption, looked-after children, safeguarding.",
+                      "document_type": "taxon",
+                      "publishing_app": "content-tagger",
+                      "rendering_app": "collections",
+                      "schema_name": "taxon",
+                      "user_journey_document_supertype": "finding",
+                      "links": {}
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        }
+      ]
+    }
+  },
+  {
+    "base_path": "/childcare-parenting/funding-and-finance-for-childcare-providers",
+    "content_id": "89b2ca59-0a37-4576-b226-95bde1e9efc4",
+    "title": "Funding and finance for childcare providers",
+    "description": "Pupil premium, early years pupil premium, early education enitlement. ",
+    "document_type": "taxon",
+    "publishing_app": "content-tagger",
+    "rendering_app": "collections",
+    "schema_name": "taxon",
+    "user_journey_document_supertype": "finding",
+    "links": {
+      "child_taxons": [],
+      "parent_taxons": [
+        {
+          "base_path": "/childcare-parenting/providing-childcare",
+          "content_id": "18cb575a-45a0-4ab8-8bff-12c48a2ee8d4",
+          "title": "Providing childcare",
+          "description": "Become a childcare provider, early years curriculum, early years funding. ",
+          "document_type": "taxon",
+          "publishing_app": "content-tagger",
+          "rendering_app": "collections",
+          "schema_name": "taxon",
+          "user_journey_document_supertype": "finding",
+          "links": {
+            "parent_taxons": [
+              {
+                "base_path": "/childcare-parenting/childcare-and-early-years",
+                "content_id": "f1d9c348-5c5e-4fc6-9172-13a62537d3ae",
+                "title": "Childcare and early years",
+                "description": "Finding childcare, running a childcare business, financial support.",
+                "document_type": "taxon",
+                "publishing_app": "content-tagger",
+                "rendering_app": "collections",
+                "schema_name": "taxon",
+                "user_journey_document_supertype": "finding",
+                "links": {
+                  "parent_taxons": [
+                    {
+                      "base_path": "/childcare-parenting",
+                      "content_id": "206b7f3a-49b5-476f-af0f-fd27e2a68473",
+                      "title": "Parenting, childcare and children's services ",
+                      "description": "Health and welfare, financial help, finding a school, adoption, looked-after children, safeguarding.",
+                      "document_type": "taxon",
+                      "publishing_app": "content-tagger",
+                      "rendering_app": "collections",
+                      "schema_name": "taxon",
+                      "user_journey_document_supertype": "finding",
+                      "links": {}
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        }
+      ]
+    }
+  },
+  {
+    "base_path": "/childcare-parenting/childrens-centres",
+    "content_id": "932cd756-d3ae-4f9d-a7bb-8b7178dc9adb",
+    "title": "Children's centres",
+    "description": "Inspections, Sure Start.",
+    "document_type": "taxon",
+    "publishing_app": "content-tagger",
+    "rendering_app": "collections",
+    "schema_name": "taxon",
+    "user_journey_document_supertype": "finding",
+    "links": {
+      "child_taxons": [],
+      "parent_taxons": [
+        {
+          "base_path": "/childcare-parenting/providing-childcare",
+          "content_id": "18cb575a-45a0-4ab8-8bff-12c48a2ee8d4",
+          "title": "Providing childcare",
+          "description": "Become a childcare provider, early years curriculum, early years funding. ",
+          "document_type": "taxon",
+          "publishing_app": "content-tagger",
+          "rendering_app": "collections",
+          "schema_name": "taxon",
+          "user_journey_document_supertype": "finding",
+          "links": {
+            "parent_taxons": [
+              {
+                "base_path": "/childcare-parenting/childcare-and-early-years",
+                "content_id": "f1d9c348-5c5e-4fc6-9172-13a62537d3ae",
+                "title": "Childcare and early years",
+                "description": "Finding childcare, running a childcare business, financial support.",
+                "document_type": "taxon",
+                "publishing_app": "content-tagger",
+                "rendering_app": "collections",
+                "schema_name": "taxon",
+                "user_journey_document_supertype": "finding",
+                "links": {
+                  "parent_taxons": [
+                    {
+                      "base_path": "/childcare-parenting",
+                      "content_id": "206b7f3a-49b5-476f-af0f-fd27e2a68473",
+                      "title": "Parenting, childcare and children's services ",
+                      "description": "Health and welfare, financial help, finding a school, adoption, looked-after children, safeguarding.",
+                      "document_type": "taxon",
+                      "publishing_app": "content-tagger",
+                      "rendering_app": "collections",
+                      "schema_name": "taxon",
+                      "user_journey_document_supertype": "finding",
+                      "links": {}
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        }
+      ]
+    }
+  },
+  {
+    "base_path": "/childcare-parenting/Early-years-curriculum-0-to-5",
+    "content_id": "b508d8eb-de70-4e08-b7d9-9e4a9f5bedae",
+    "title": "Early years curriculum (0 to 5)",
+    "description": "Early Years Foundation Stage.",
+    "document_type": "taxon",
+    "publishing_app": "content-tagger",
+    "rendering_app": "collections",
+    "schema_name": "taxon",
+    "user_journey_document_supertype": "finding",
+    "links": {
+      "child_taxons": [],
+      "parent_taxons": [
+        {
+          "base_path": "/childcare-parenting/providing-childcare",
+          "content_id": "18cb575a-45a0-4ab8-8bff-12c48a2ee8d4",
+          "title": "Providing childcare",
+          "description": "Become a childcare provider, early years curriculum, early years funding. ",
+          "document_type": "taxon",
+          "publishing_app": "content-tagger",
+          "rendering_app": "collections",
+          "schema_name": "taxon",
+          "user_journey_document_supertype": "finding",
+          "links": {
+            "parent_taxons": [
+              {
+                "base_path": "/childcare-parenting/childcare-and-early-years",
+                "content_id": "f1d9c348-5c5e-4fc6-9172-13a62537d3ae",
+                "title": "Childcare and early years",
+                "description": "Finding childcare, running a childcare business, financial support.",
+                "document_type": "taxon",
+                "publishing_app": "content-tagger",
+                "rendering_app": "collections",
+                "schema_name": "taxon",
+                "user_journey_document_supertype": "finding",
+                "links": {
+                  "parent_taxons": [
+                    {
+                      "base_path": "/childcare-parenting",
+                      "content_id": "206b7f3a-49b5-476f-af0f-fd27e2a68473",
+                      "title": "Parenting, childcare and children's services ",
+                      "description": "Health and welfare, financial help, finding a school, adoption, looked-after children, safeguarding.",
+                      "document_type": "taxon",
+                      "publishing_app": "content-tagger",
+                      "rendering_app": "collections",
+                      "schema_name": "taxon",
+                      "user_journey_document_supertype": "finding",
+                      "links": {}
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        }
+      ]
+    }
+  },
+  {
+    "base_path": "/childcare-parenting/becoming-a-childcare-provider",
+    "content_id": "39e60ce9-5b21-49e9-919f-2cf3ffa4b075",
+    "title": "Becoming a childcare provider",
+    "description": "Register with Ofsted, agencies, children's social care providers, financial references, DBS checks.",
+    "document_type": "taxon",
+    "publishing_app": "content-tagger",
+    "rendering_app": "collections",
+    "schema_name": "taxon",
+    "user_journey_document_supertype": "finding",
+    "links": {
+      "child_taxons": [],
+      "parent_taxons": [
+        {
+          "base_path": "/childcare-parenting/providing-childcare",
+          "content_id": "18cb575a-45a0-4ab8-8bff-12c48a2ee8d4",
+          "title": "Providing childcare",
+          "description": "Become a childcare provider, early years curriculum, early years funding. ",
+          "document_type": "taxon",
+          "publishing_app": "content-tagger",
+          "rendering_app": "collections",
+          "schema_name": "taxon",
+          "user_journey_document_supertype": "finding",
+          "links": {
+            "parent_taxons": [
+              {
+                "base_path": "/childcare-parenting/childcare-and-early-years",
+                "content_id": "f1d9c348-5c5e-4fc6-9172-13a62537d3ae",
+                "title": "Childcare and early years",
+                "description": "Finding childcare, running a childcare business, financial support.",
+                "document_type": "taxon",
+                "publishing_app": "content-tagger",
+                "rendering_app": "collections",
+                "schema_name": "taxon",
+                "user_journey_document_supertype": "finding",
+                "links": {
+                  "parent_taxons": [
+                    {
+                      "base_path": "/childcare-parenting",
+                      "content_id": "206b7f3a-49b5-476f-af0f-fd27e2a68473",
+                      "title": "Parenting, childcare and children's services ",
+                      "description": "Health and welfare, financial help, finding a school, adoption, looked-after children, safeguarding.",
+                      "document_type": "taxon",
+                      "publishing_app": "content-tagger",
+                      "rendering_app": "collections",
+                      "schema_name": "taxon",
+                      "user_journey_document_supertype": "finding",
+                      "links": {}
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        }
+      ]
+    }
+  },
+  {
+    "base_path": "/childcare-parenting/local-authority-early-years-funding-and-obligations",
+    "content_id": "1da1c700-cef8-45c4-9bb7-11a4b0003e10",
+    "title": "Local authority early years funding and obligations",
+    "description": "Entitlement guide, providing early education and childcare. ",
+    "document_type": "taxon",
+    "publishing_app": "content-tagger",
+    "rendering_app": "collections",
+    "schema_name": "taxon",
+    "user_journey_document_supertype": "finding",
+    "links": {
+      "child_taxons": [],
+      "parent_taxons": [
+        {
+          "base_path": "/childcare-parenting/providing-childcare",
+          "content_id": "18cb575a-45a0-4ab8-8bff-12c48a2ee8d4",
+          "title": "Providing childcare",
+          "description": "Become a childcare provider, early years curriculum, early years funding. ",
+          "document_type": "taxon",
+          "publishing_app": "content-tagger",
+          "rendering_app": "collections",
+          "schema_name": "taxon",
+          "user_journey_document_supertype": "finding",
+          "links": {
+            "parent_taxons": [
+              {
+                "base_path": "/childcare-parenting/childcare-and-early-years",
+                "content_id": "f1d9c348-5c5e-4fc6-9172-13a62537d3ae",
+                "title": "Childcare and early years",
+                "description": "Finding childcare, running a childcare business, financial support.",
+                "document_type": "taxon",
+                "publishing_app": "content-tagger",
+                "rendering_app": "collections",
+                "schema_name": "taxon",
+                "user_journey_document_supertype": "finding",
+                "links": {
+                  "parent_taxons": [
+                    {
+                      "base_path": "/childcare-parenting",
+                      "content_id": "206b7f3a-49b5-476f-af0f-fd27e2a68473",
+                      "title": "Parenting, childcare and children's services ",
+                      "description": "Health and welfare, financial help, finding a school, adoption, looked-after children, safeguarding.",
+                      "document_type": "taxon",
+                      "publishing_app": "content-tagger",
+                      "rendering_app": "collections",
+                      "schema_name": "taxon",
+                      "user_journey_document_supertype": "finding",
+                      "links": {}
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        }
+      ]
+    }
+  },
+  {
+    "base_path": "/childcare-parenting/performance-and-inspection-of-childcare-providers",
+    "content_id": "b52d05ab-bc36-4a68-9bbf-63417788af3c",
+    "title": "Performance and inspection of childcare providers",
+    "description": "Early years information, inspection guidance, Ofsted registration fee. ",
+    "document_type": "taxon",
+    "publishing_app": "content-tagger",
+    "rendering_app": "collections",
+    "schema_name": "taxon",
+    "user_journey_document_supertype": "finding",
+    "links": {
+      "child_taxons": [],
+      "parent_taxons": [
+        {
+          "base_path": "/childcare-parenting/providing-childcare",
+          "content_id": "18cb575a-45a0-4ab8-8bff-12c48a2ee8d4",
+          "title": "Providing childcare",
+          "description": "Become a childcare provider, early years curriculum, early years funding. ",
+          "document_type": "taxon",
+          "publishing_app": "content-tagger",
+          "rendering_app": "collections",
+          "schema_name": "taxon",
+          "user_journey_document_supertype": "finding",
+          "links": {
+            "parent_taxons": [
+              {
+                "base_path": "/childcare-parenting/childcare-and-early-years",
+                "content_id": "f1d9c348-5c5e-4fc6-9172-13a62537d3ae",
+                "title": "Childcare and early years",
+                "description": "Finding childcare, running a childcare business, financial support.",
+                "document_type": "taxon",
+                "publishing_app": "content-tagger",
+                "rendering_app": "collections",
+                "schema_name": "taxon",
+                "user_journey_document_supertype": "finding",
+                "links": {
+                  "parent_taxons": [
+                    {
+                      "base_path": "/childcare-parenting",
+                      "content_id": "206b7f3a-49b5-476f-af0f-fd27e2a68473",
+                      "title": "Parenting, childcare and children's services ",
+                      "description": "Health and welfare, financial help, finding a school, adoption, looked-after children, safeguarding.",
+                      "document_type": "taxon",
+                      "publishing_app": "content-tagger",
+                      "rendering_app": "collections",
+                      "schema_name": "taxon",
+                      "user_journey_document_supertype": "finding",
+                      "links": {}
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        }
+      ]
+    }
+  },
+  {
+    "base_path": "/childcare-parenting/qualifications-training-and-professional-development-for-childcare-providers",
+    "content_id": "f002c7d4-9d6c-4ad8-8174-28ec7d4510fe",
+    "title": "Qualifications, training and professional development for childcare providers",
+    "description": "Qualifications criteria.",
+    "document_type": "taxon",
+    "publishing_app": "content-tagger",
+    "rendering_app": "collections",
+    "schema_name": "taxon",
+    "user_journey_document_supertype": "finding",
+    "links": {
+      "child_taxons": [],
+      "parent_taxons": [
+        {
+          "base_path": "/childcare-parenting/providing-childcare",
+          "content_id": "18cb575a-45a0-4ab8-8bff-12c48a2ee8d4",
+          "title": "Providing childcare",
+          "description": "Become a childcare provider, early years curriculum, early years funding. ",
+          "document_type": "taxon",
+          "publishing_app": "content-tagger",
+          "rendering_app": "collections",
+          "schema_name": "taxon",
+          "user_journey_document_supertype": "finding",
+          "links": {
+            "parent_taxons": [
+              {
+                "base_path": "/childcare-parenting/childcare-and-early-years",
+                "content_id": "f1d9c348-5c5e-4fc6-9172-13a62537d3ae",
+                "title": "Childcare and early years",
+                "description": "Finding childcare, running a childcare business, financial support.",
+                "document_type": "taxon",
+                "publishing_app": "content-tagger",
+                "rendering_app": "collections",
+                "schema_name": "taxon",
+                "user_journey_document_supertype": "finding",
+                "links": {
+                  "parent_taxons": [
+                    {
+                      "base_path": "/childcare-parenting",
+                      "content_id": "206b7f3a-49b5-476f-af0f-fd27e2a68473",
+                      "title": "Parenting, childcare and children's services ",
+                      "description": "Health and welfare, financial help, finding a school, adoption, looked-after children, safeguarding.",
+                      "document_type": "taxon",
+                      "publishing_app": "content-tagger",
+                      "rendering_app": "collections",
+                      "schema_name": "taxon",
+                      "user_journey_document_supertype": "finding",
+                      "links": {}
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        }
+      ]
+    }
+  },
+  {
+    "base_path": "/childcare-parenting/youth-employment-and-social-issues",
+    "content_id": "43fcdde6-59c5-487f-a969-a046b334cbec",
+    "title": "Youth employment and social issues",
+    "description": "Developing social and emotional skills, improving outcomes, best practice for commissioning.",
+    "document_type": "taxon",
+    "publishing_app": "content-tagger",
+    "rendering_app": "collections",
+    "schema_name": "taxon",
+    "user_journey_document_supertype": "finding",
+    "links": {
+      "child_taxons": [],
+      "parent_taxons": [
+        {
+          "base_path": "/childcare-parenting",
+          "content_id": "206b7f3a-49b5-476f-af0f-fd27e2a68473",
+          "title": "Parenting, childcare and children's services ",
+          "description": "Health and welfare, financial help, finding a school, adoption, looked-after children, safeguarding.",
+          "document_type": "taxon",
+          "publishing_app": "content-tagger",
+          "rendering_app": "collections",
+          "schema_name": "taxon",
+          "user_journey_document_supertype": "finding",
+          "links": {}
+        }
+      ]
+    }
+  }
+]


### PR DESCRIPTION
The Parenting and Childcare taxonomy currently exists in a draft format
on the Draft Content Store. We would like to test the navigation
prototype with the draft taxonomy, but cannot access the draft content
store unless we deploy the prototype to GOV.UK infrastructure.

Since deploying to GOV.UK infrastructure would make the deployment
process harder, we instead hardcode the draft taxonomy file in a JSON
file retrieved with a Rake task from Content Tagger.

When we make a request for a content item, we first check if this
content item exists in the local JSON file. If it does, then return
that instead.

This change also updates the GOV.UK homepage to point to the correct
taxon page, which doesn’t exist as a Production feature yet.

### Trello

https://trello.com/c/i3YMQLaT/242-spike-download-draft-taxons-from-draft-content-store-and-serve-them-in-the-prototype